### PR TITLE
Proposal hash and blake2_256 are now computed from the raw bytes

### DIFF
--- a/libs/wasm-testbed/src/lib.rs
+++ b/libs/wasm-testbed/src/lib.rs
@@ -168,13 +168,13 @@ impl WasmTestBed {
 
 	/// Compute the proposal hash of the runtime
 	pub fn proposal_hash(&self) -> String {
-		let result: SrhResult = get_result(&self.wasm);
+		let result: SrhResult = get_result(&self.bytes);
 		format!("0x{}", &result.encodedd_hash)
 	}
 
 	/// Compute the blake2-256 hash of the runtime
 	pub fn blake2_256_hash(&self) -> String {
-		let result = BlakeTwo256::hash(&self.wasm);
+		let result = BlakeTwo256::hash(&self.bytes);
 		format!("{:?}", result)
 	}
 }


### PR DESCRIPTION
Until now, both the proposal hash and the blake2-256 were compuetd after decompression, leading to the same hash whether the observed runtimes was compressed or not.
This causes issues comparing the call hashes onchain as those do consider the compressed data. This PR fixes this.
