### PR TITLE
Add parachain related hashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3022,7 +3022,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-runtime-proposal-hash"
-version = "0.13.0"
+version = "0.12.0"
 dependencies = [
  "blake2",
  "frame-metadata",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3022,7 +3022,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-runtime-proposal-hash"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "blake2",
  "frame-metadata",
@@ -3653,6 +3653,7 @@ name = "wasm-testbed"
 version = "0.12.1"
 dependencies = [
  "frame-metadata",
+ "hex",
  "parity-scale-codec",
  "sc-executor",
  "sp-core",

--- a/lib/src/runtime_info.rs
+++ b/lib/src/runtime_info.rs
@@ -14,6 +14,7 @@ pub struct RuntimeInfo {
 	metadata_version: u8,
 	core_version: String,
 	proposal_hash: String,
+	parachain_authorize_upgrade_hash: String,
 	ipfs_hash: String,
 	blake2_256: String,
 }
@@ -35,6 +36,7 @@ impl RuntimeInfo {
 			metadata_version: *testbed.metadata_version(),
 			core_version,
 			proposal_hash: testbed.proposal_hash(),
+			parachain_authorize_upgrade_hash: testbed.parachain_authorize_upgrade_hash(),
 			ipfs_hash: hasher.compute(testbed.raw_bytes()),
 			blake2_256: testbed.blake2_256_hash(),
 		}
@@ -56,25 +58,26 @@ impl Display for RuntimeInfo {
 	fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		let size_mb: f64 = self.size as f64 / 1024.0 / 1024.0;
 
-		writeln!(fmt, "🏋️  Runtime size:\t{:.3?} MB ({} bytes)", size_mb, self.size.to_formatted_string(&Locale::en))?;
+		writeln!(fmt, "🏋️  Runtime size:\t\t{:.3?} MB ({} bytes)", size_mb, self.size.to_formatted_string(&Locale::en))?;
 		if self.compression.compressed() {
-			writeln!(fmt, "🗜  Compressed:\t\tYes, {:.2}%", 100f32 - self.compression.compression_ratio() * 100f32)?;
+			writeln!(fmt, "🗜  Compressed:\t\t\tYes, {:.2}%", 100f32 - self.compression.compression_ratio() * 100f32)?;
 		} else {
-			writeln!(fmt, "🗜  Compressed:\t\tNo")?;
+			writeln!(fmt, "🗜  Compressed:\t\t\tNo")?;
 		}
 
 		writeln!(
 			fmt,
-			"✨ Reserved meta:\t{} - {:02X?}",
+			"✨ Reserved meta:\t\t{} - {:02X?}",
 			if self.reserved_meta_valid { "OK" } else { "Unknown!" },
 			self.reserved_meta,
 		)?;
-		writeln!(fmt, "🎁 Metadata version:\tV{:?}", self.metadata_version)?;
-		writeln!(fmt, "🔥 Core version:\t{}", self.core_version)?;
-		writeln!(fmt, "🗳️  Proposal hash:\t{}", self.proposal_hash)?;
-		writeln!(fmt, "#️⃣  Blake2-256 hash:\t{}", self.blake2_256)?;
+		writeln!(fmt, "🎁 Metadata version:\t\tV{:?}", self.metadata_version)?;
+		writeln!(fmt, "🔥 Core version:\t\t{}", self.core_version)?;
+		writeln!(fmt, "🗳️  system.setCode hash:\t\t{}", self.proposal_hash)?;
+		writeln!(fmt, "🗳️  authorizedUpgrade hash:\t{}", self.parachain_authorize_upgrade_hash)?;
+		writeln!(fmt, "#️⃣  Blake2-256 hash:\t\t{}", self.blake2_256)?;
 		let ipfs_url = format!("https://www.ipfs.io/ipfs/{cid}", cid = self.ipfs_hash);
-		writeln!(fmt, "📦 IPFS hash:\t\t{} ({url})", self.ipfs_hash, url = ipfs_url)?;
+		writeln!(fmt, "📦 IPFS hash:\t\t\t{} ({url})", self.ipfs_hash, url = ipfs_url)?;
 		Ok(())
 	}
 }

--- a/libs/substrate-runtime-proposal-hash/Cargo.toml
+++ b/libs/substrate-runtime-proposal-hash/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["wasm", "cli", "substrate", "blockchain", "runtime", "polkadot", "ku
 name = "substrate-runtime-proposal-hash"
 readme = "README.md"
 repository = "https://github.com/chevdor/subwasm"
-version = "0.13.0"
+version = "0.12.0"
 
 [dependencies]
 blake2 = "0.9"

--- a/libs/substrate-runtime-proposal-hash/Cargo.toml
+++ b/libs/substrate-runtime-proposal-hash/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["wasm", "cli", "substrate", "blockchain", "runtime", "polkadot", "ku
 name = "substrate-runtime-proposal-hash"
 readme = "README.md"
 repository = "https://github.com/chevdor/subwasm"
-version = "0.12.0"
+version = "0.13.0"
 
 [dependencies]
 blake2 = "0.9"

--- a/libs/substrate-runtime-proposal-hash/src/lib.rs
+++ b/libs/substrate-runtime-proposal-hash/src/lib.rs
@@ -1,22 +1,27 @@
 use blake2::digest::{Update, VariableOutput};
 use blake2::VarBlake2b;
 use codec::Encode;
+use sp_core::Hasher;
+use sp_runtime::traits::BlakeTwo256;
 use std::convert::TryInto;
 
 /// Expected size of the hash
 pub const SIZE: usize = 32;
 
 /// Type for our Proposal hash
-pub type ProposalHash = [u8; SIZE];
+pub type CalllHash = [u8; SIZE];
+
+type Prefix = (u8, u8);
 
 /// The PREFIX is prepended to the data before hashing
-const PREFIX: [u8; 2] = [0x00, 0x03];
+pub const PREFIX_SYSTEM_SETCODE: Prefix = (0x00, 0x03);
+pub const PREFIX_PARACHAINSYSTEM_AUTHORIZE_UPGRADE: Prefix = (0x01, 0x03);
 
 /// This struct is a container for whatever we calculated.
 #[derive(Debug)]
 pub struct SrhResult {
 	/// This is the PropsalHash itself, not encoded
-	pub hash: ProposalHash,
+	pub hash: CalllHash,
 
 	/// Hex encoded proposal hash.
 	pub encodedd_hash: String,
@@ -30,9 +35,9 @@ pub fn concatenate_arrays<T: Clone>(x: &[T], y: &[T]) -> Vec<T> {
 }
 
 /// Generate our result object
-pub fn get_result(buffer: &[u8]) -> SrhResult {
+pub fn get_result(prefix: Prefix, buffer: &[u8]) -> SrhResult {
 	buffer.using_encoded(|wasm_blob| {
-		let hash = get_proposal_hash(wasm_blob);
+		let hash = get_call_hash(prefix, wasm_blob);
 
 		SrhResult { hash, encodedd_hash: hex::encode(hash) }
 	})
@@ -43,11 +48,26 @@ pub fn get_result(buffer: &[u8]) -> SrhResult {
 /// # Arguments
 /// * `wasm_blob` - The WASM blob
 /// # Returns
-/// * `ProposalHash` - The hash of the proposal as calculated on chain
-fn get_proposal_hash(wasm_blob: &[u8]) -> ProposalHash {
+/// * `CalllHash` - The hash of the proposal as calculated on chain
+/// @deprecated
+pub fn get_proposal_hash(wasm_blob: &[u8]) -> CalllHash {
+	get_call_hash(PREFIX_SYSTEM_SETCODE, wasm_blob)
+}
+
+/// This function replaces the deprecated `get_proposal_hash`
+pub fn get_system_setcode(wasm_blob: &[u8]) -> CalllHash {
+	get_call_hash(PREFIX_SYSTEM_SETCODE, wasm_blob)
+}
+
+pub fn get_parachainsystem_authorize_upgrade(wasm_blob: &[u8]) -> CalllHash {
+	let code_hash = BlakeTwo256::hash(&wasm_blob);
+	get_call_hash(PREFIX_PARACHAINSYSTEM_AUTHORIZE_UPGRADE, code_hash.as_bytes())
+}
+
+fn get_call_hash(prefix: Prefix, wasm_blob: &[u8]) -> CalllHash {
 	let mut hasher = VarBlake2b::new(SIZE).unwrap();
-	hasher.update(concatenate_arrays(&PREFIX, wasm_blob));
-	let mut result: ProposalHash = [0; SIZE];
+	hasher.update(concatenate_arrays(&[prefix.0, prefix.1], wasm_blob));
+	let mut result: CalllHash = [0; SIZE];
 	hasher.finalize_variable(|res| {
 		result = res.try_into().expect("slice with incorrect length");
 	});
@@ -59,12 +79,36 @@ mod tests {
 	use super::*;
 
 	#[test]
-	fn test_hash() {
+	fn test_proposal_hash() {
 		assert_eq!(
 			get_proposal_hash(&[1, 2, 42]),
 			[
 				156, 244, 243, 93, 21, 8, 113, 238, 186, 17, 20, 52, 240, 236, 140, 15, 108, 26, 86, 5, 152, 148, 91,
 				162, 108, 168, 3, 65, 254, 162, 114, 46
+			]
+		);
+	}
+
+	#[test]
+	fn test_call_hash() {
+		assert_eq!(
+			get_call_hash(PREFIX_SYSTEM_SETCODE, &[1, 2, 42]),
+			[
+				156, 244, 243, 93, 21, 8, 113, 238, 186, 17, 20, 52, 240, 236, 140, 15, 108, 26, 86, 5, 152, 148, 91,
+				162, 108, 168, 3, 65, 254, 162, 114, 46
+			]
+		);
+	}
+
+	#[test]
+	fn test_parachain_upgrade() {
+		assert_eq!(
+			get_parachainsystem_authorize_upgrade(&[
+				0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x97, 0x03, 0x39, 0x60, 0x03, 0x7f, 0x7f
+			]),
+			[
+				136, 242, 183, 110, 31, 66, 126, 20, 192, 209, 151, 203, 156, 215, 131, 200, 97, 163, 230, 157, 86,
+				220, 102, 180, 58, 141, 176, 52, 178, 133, 149, 179
 			]
 		);
 	}
@@ -76,14 +120,14 @@ mod tests {
 
 	#[test]
 	fn test_get_result() {
-		let res = get_result(&[1, 2, 42]);
+		let res = get_result(PREFIX_SYSTEM_SETCODE, &[1, 2, 42]);
 		assert!(res.encodedd_hash == "9388ba11b3f2a5db3ef9bf237f1c88ffb369d77ffa843fc67570c89c09fa9c0e");
 	}
 
 	#[test]
 	fn test_long_input() {
 		const SIZE_8MB: usize = 8 * 1024 * 1024;
-		let res = get_result(&[0; SIZE_8MB]);
+		let res = get_result(PREFIX_SYSTEM_SETCODE, &[0; SIZE_8MB]);
 		assert!(res.encodedd_hash == "9348da94fcffe94318313f8ce237211a7fd6c1531ab21b61606a1f7eeb8b2409");
 	}
 }

--- a/libs/wasm-testbed/Cargo.toml
+++ b/libs/wasm-testbed/Cargo.toml
@@ -9,8 +9,9 @@ repository = "https://github.com/chevdor/subwasm"
 version = "0.12.1"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "2.2" }
+codec = {package = "parity-scale-codec", version = "2.2"}
 frame-metadata = {package = "frame-metadata", git = "https://github.com/paritytech/frame-metadata", branch = "main"}
+hex = "0.4"
 sc-executor = "0.9"
 sp-core = "3.0"
 sp-io = "3.0"

--- a/libs/wasm-testbed/src/lib.rs
+++ b/libs/wasm-testbed/src/lib.rs
@@ -9,7 +9,7 @@ use sp_core::Hasher;
 use sp_runtime::traits::BlakeTwo256;
 use sp_wasm_interface::HostFunctions;
 use std::fmt;
-use substrate_runtime_proposal_hash::{get_result, SrhResult};
+use substrate_runtime_proposal_hash::{get_parachainsystem_authorize_upgrade, get_result, SrhResult};
 use wasm_loader::*;
 
 /// This is a "magic" number signaling that out Wasm is a substrate wasm.
@@ -168,8 +168,14 @@ impl WasmTestBed {
 
 	/// Compute the proposal hash of the runtime
 	pub fn proposal_hash(&self) -> String {
-		let result: SrhResult = get_result(&self.bytes);
+		let result: SrhResult = get_result(substrate_runtime_proposal_hash::PREFIX_SYSTEM_SETCODE, &self.wasm);
 		format!("0x{}", &result.encodedd_hash)
+	}
+
+	/// Compute the proposal hash of the runtime
+	pub fn parachain_authorize_upgrade_hash(&self) -> String {
+		let result = get_parachainsystem_authorize_upgrade(&self.bytes);
+		format!("0x{}", hex::encode(result))
 	}
 
 	/// Compute the blake2-256 hash of the runtime


### PR DESCRIPTION
This PR bring a new hash, useful for parachain upgrades.

Hashes below are truncated for readability:

```
🏋️  Runtime size:                0.455 MB (476,662 bytes)
🗜  Compressed:                  Yes, 71.54%
✨ Reserved meta:               OK - [6D, 65, 74, 61]
🎁 Metadata version:            V13
🔥 Core version:                westmint-2 (westmint-0.tx1.au1)
🗳️  system.setCode hash:         0xd3...0be54
🗳️  authorizedUpgrade hash:      0xb48...212d1b      <-- HERE
#️⃣  Blake2-256 hash:             0x3a0...1026a1
📦 IPFS hash:                   QmY...Ln (https://www.ipfs.io/ipfs/QmY...Ln)
```
