### PR TITLE
Fix get to return the original compressed runtime

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -75,7 +75,7 @@ pub fn download_runtime(url: &str, block_ref: Option<BlockRef>, output: Option<P
 
 	let loader =
 		wasm_loader::WasmLoader::load_from_source(&Source::Chain(reference)).expect("Getting wasm from the node");
-	let wasm = loader.uncompressed_bytes();
+	let wasm = loader.original_bytes();
 
 	info!("Got the runtime, its size is {:?}", wasm.len());
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -75,7 +75,7 @@ pub fn download_runtime(url: &str, block_ref: Option<BlockRef>, output: Option<P
 
 	let loader =
 		wasm_loader::WasmLoader::load_from_source(&Source::Chain(reference)).expect("Getting wasm from the node");
-	let wasm = loader.bytes();
+	let wasm = loader.uncompressed_bytes();
 
 	info!("Got the runtime, its size is {:?}", wasm.len());
 

--- a/libs/ipfs-hasher/src/lib.rs
+++ b/libs/ipfs-hasher/src/lib.rs
@@ -69,10 +69,10 @@ mod tests {
 	fn it_computes_a_runtime_ipfs_hash() {
 		const POLKADOT_BLOCK20: &str = "0x4d6a0bca208b85d41833a7f35cf73d1ae6974f4bad8ab576e2c3f751d691fe6c"; // Polkadot Block #20
 
-		let ocb = OnchainBlock::new("wss://rpc.polkadot.io", Some(POLKADOT_BLOCK20.to_string()));
+		let ocb = OnchainBlock::new("wss://rpc.polkadot.io:443", Some(POLKADOT_BLOCK20.to_string()));
 		let loader = WasmLoader::load_from_source(&Source::Chain(ocb)).unwrap();
 		let hasher = IpfsHasher::default();
-		let cid = hasher.compute(loader.bytes());
+		let cid = hasher.compute(loader.uncompressed_bytes());
 		assert!(cid == "QmevKMGkRViXfQMSZ38DBdcJ1cXcXf9sXdfXie8Jkc7ZGs");
 	}
 }

--- a/libs/wasm-testbed/src/lib.rs
+++ b/libs/wasm-testbed/src/lib.rs
@@ -53,7 +53,7 @@ impl WasmTestBed {
 	pub fn new(source: &Source) -> Result<Self> {
 		let loader = WasmLoader::load_from_source(source).map_err(|_| WasmTestbedError::Loading(source.to_string()))?;
 
-		let wasm = loader.bytes().to_vec();
+		let wasm = loader.uncompressed_bytes().to_vec();
 		let metadata_encoded = Self::call(&wasm, "Metadata_metadata", &[])?;
 		let metadata =
 			<Vec<u8>>::decode(&mut &metadata_encoded[..]).map_err(|_| WasmTestbedError::Decoding(metadata_encoded))?;
@@ -76,7 +76,7 @@ impl WasmTestBed {
 
 		Ok(Self {
 			wasm,
-			bytes: loader.uncompressed_bytes().to_vec(),
+			bytes: loader.original_bytes().to_vec(),
 			runtime_metadata_prefixed,
 			metadata,
 			metadata_version,


### PR DESCRIPTION
I tested on westend where the runtime is compressed and here is the before/after:

Before: the runtime is ERRONEOUSLY returned uncompressed
```
[2021-10-30T14:28:08Z INFO  subwasm] Running subwasm v0.14.1
[2021-10-30T14:28:08Z INFO  subwasm] ⏱️  Loading WASM from File("/tmp/before.wasm")
🏋️  Runtime size:                4.237 MB (4,442,749 bytes)
🗜  Compressed:                  No
✨ Reserved meta:               OK - [6D, 65, 74, 61]
🎁 Metadata version:            V14
🔥 Core version:                westend-9122 (parity-westend-0.tx7.au2)
🗳️  system.setCode hash:         0xc71d8e95a829338f879f984cb3e151c4d4cb988a8583d5b8b06bc3547b8dc917
🗳️  authorizeUpgrade hash:       0x077f43eac7e0ecb918bc90d12d20ea208d83dec0294d971f549a5fbd0a980cd7
#️⃣  Blake2-256 hash:             0x82dfab05b7b35bd69cc8e7fd882d426605b8c43a6e5ab3c2c6a8758c3353ce47
📦 IPFS:                        https://www.ipfs.io/ipfs/Qmdeo61gnGCUNXKhYGk13zWvc5VtwhQGKKshurjAWwbvFn
```

After: the runtime is this time returned as it is on chain:
```
[2021-10-30T14:28:15Z INFO  subwasm] Running subwasm v0.14.1
[2021-10-30T14:28:15Z INFO  subwasm] ⏱️  Loading WASM from File("/tmp/after.wasm")
🏋️  Runtime size:                1.000 MB (1,048,228 bytes)
🗜  Compressed:                  Yes, 76.41%
✨ Reserved meta:               OK - [6D, 65, 74, 61]
🎁 Metadata version:            V14
🔥 Core version:                westend-9122 (parity-westend-0.tx7.au2)
🗳️  system.setCode hash:         0xbafbb411cc77129268eb22382d7dc2065abda67aeffdf5f82e579c021d2c8a8b
🗳️  authorizeUpgrade hash:       0x406230d546115fdce7ca97ea0e7ad2c3969fdc69ee01003e73b976b35101cab5
#️⃣  Blake2-256 hash:             0x2c45edfdbb4c2038b50b86c1f3e8dd0a6e6f61cf65aeb272d16be1ccc1a01a4a
📦 IPFS:                        https://www.ipfs.io/ipfs/QmT231JEibR4eiu9kfh7vnodWcmvE3ggh6S733PEatKuE8
```

fix #21