### PR TITLE
Dependency sp-maybe-compressed-blob version bump to 4.1.0-dev

### DIFF
--- a/libs/wasm-loader/Cargo.toml
+++ b/libs/wasm-loader/Cargo.toml
@@ -16,5 +16,5 @@ log = "0.4"
 multibase = "0.9"
 multihash = "0.15"
 serde = {version = "1.0", features = ["derive"]}
-sp-maybe-compressed-blob = {version = "^4.0.0-dev", git = "https://github.com/paritytech/substrate/"}
+sp-maybe-compressed-blob = {version = "4.1.0-dev", git = "https://github.com/paritytech/substrate/"}
 tokio = {version = "1.11", features = ["full"]}

--- a/libs/wasm-loader/Cargo.toml
+++ b/libs/wasm-loader/Cargo.toml
@@ -16,5 +16,5 @@ log = "0.4"
 multibase = "0.9"
 multihash = "0.15"
 serde = {version = "1.0", features = ["derive"]}
-sp-maybe-compressed-blob = {version = "4.0.0-dev", git = "https://github.com/paritytech/substrate/"}
+sp-maybe-compressed-blob = {version = "^4.0.0-dev", git = "https://github.com/paritytech/substrate/"}
 tokio = {version = "1.11", features = ["full"]}


### PR DESCRIPTION
When building https://github.com/polkascan/py-subwasm-bindings it results in the following build error:

```
error: no matching package found
searched package name: `sp-maybe-compressed-blob`
prerelease package needs to be specified explicitly
sp-maybe-compressed-blob = { version = "4.1.0-dev" }
location searched: https://github.com/paritytech/substrate/
required by package `wasm-loader v0.16.0 (https://github.com/chevdor/subwasm?tag=v0.16.0#80fc9e7d)
```

Probably because of recent version bump of https://github.com/paritytech/substrate/blob/master/primitives/maybe-compressed-blob/Cargo.toml