### PR TITLE
Bump `jsonrpsee`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1284,8 +1284,8 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.9.0"
-source = "git+https://github.com/paritytech/jsonrpsee#14b1b4b5c38cc8c5a418f11a9266da72fa9378cf"
+version = "0.10.1"
+source = "git+https://github.com/paritytech/jsonrpsee?tag=v0.10.1#5c8f1f77052151caff0b47ee3e1d4e0577d326c0"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -1299,8 +1299,8 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-client-transport"
-version = "0.9.0"
-source = "git+https://github.com/paritytech/jsonrpsee#14b1b4b5c38cc8c5a418f11a9266da72fa9378cf"
+version = "0.10.1"
+source = "git+https://github.com/paritytech/jsonrpsee?tag=v0.10.1#5c8f1f77052151caff0b47ee3e1d4e0577d326c0"
 dependencies = [
  "futures",
  "http",
@@ -1319,8 +1319,8 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.9.0"
-source = "git+https://github.com/paritytech/jsonrpsee#14b1b4b5c38cc8c5a418f11a9266da72fa9378cf"
+version = "0.10.1"
+source = "git+https://github.com/paritytech/jsonrpsee?tag=v0.10.1#5c8f1f77052151caff0b47ee3e1d4e0577d326c0"
 dependencies = [
  "anyhow",
  "arrayvec 0.7.2",
@@ -1343,8 +1343,8 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-http-client"
-version = "0.9.0"
-source = "git+https://github.com/paritytech/jsonrpsee#14b1b4b5c38cc8c5a418f11a9266da72fa9378cf"
+version = "0.10.1"
+source = "git+https://github.com/paritytech/jsonrpsee?tag=v0.10.1#5c8f1f77052151caff0b47ee3e1d4e0577d326c0"
 dependencies = [
  "async-trait",
  "hyper",
@@ -1361,8 +1361,8 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-http-server"
-version = "0.9.0"
-source = "git+https://github.com/paritytech/jsonrpsee#14b1b4b5c38cc8c5a418f11a9266da72fa9378cf"
+version = "0.10.1"
+source = "git+https://github.com/paritytech/jsonrpsee?tag=v0.10.1#5c8f1f77052151caff0b47ee3e1d4e0577d326c0"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -1372,7 +1372,6 @@ dependencies = [
  "jsonrpsee-types",
  "lazy_static",
  "serde_json",
- "socket2",
  "tokio",
  "tracing",
  "unicase",
@@ -1380,8 +1379,8 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.9.0"
-source = "git+https://github.com/paritytech/jsonrpsee#14b1b4b5c38cc8c5a418f11a9266da72fa9378cf"
+version = "0.10.1"
+source = "git+https://github.com/paritytech/jsonrpsee?tag=v0.10.1#5c8f1f77052151caff0b47ee3e1d4e0577d326c0"
 dependencies = [
  "proc-macro-crate 1.1.3",
  "proc-macro2",
@@ -1391,8 +1390,8 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.9.0"
-source = "git+https://github.com/paritytech/jsonrpsee#14b1b4b5c38cc8c5a418f11a9266da72fa9378cf"
+version = "0.10.1"
+source = "git+https://github.com/paritytech/jsonrpsee?tag=v0.10.1#5c8f1f77052151caff0b47ee3e1d4e0577d326c0"
 dependencies = [
  "anyhow",
  "beef",
@@ -1404,8 +1403,8 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-ws-client"
-version = "0.9.0"
-source = "git+https://github.com/paritytech/jsonrpsee#14b1b4b5c38cc8c5a418f11a9266da72fa9378cf"
+version = "0.10.1"
+source = "git+https://github.com/paritytech/jsonrpsee?tag=v0.10.1#5c8f1f77052151caff0b47ee3e1d4e0577d326c0"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -1414,8 +1413,8 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-ws-server"
-version = "0.9.0"
-source = "git+https://github.com/paritytech/jsonrpsee#14b1b4b5c38cc8c5a418f11a9266da72fa9378cf"
+version = "0.10.1"
+source = "git+https://github.com/paritytech/jsonrpsee?tag=v0.10.1#5c8f1f77052151caff0b47ee3e1d4e0577d326c0"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -3421,7 +3420,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee73e6e4924fe940354b8d4d98cad5231175d615cd855b758adc658c0aac6a0"
 dependencies = [
  "cfg-if",
- "rand 0.8.5",
+ "rand 0.7.3",
  "static_assertions",
 ]
 

--- a/libs/wasm-loader/Cargo.toml
+++ b/libs/wasm-loader/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.17.0"
 
 [dependencies]
 hex = "0.4"
-jsonrpsee = {version = "0.9", git = "https://github.com/paritytech/jsonrpsee", features = ["full"]}
+jsonrpsee = {version = "0.10.1", git = "https://github.com/paritytech/jsonrpsee", tag = "v0.10.1", features = ["full"]}
 log = "0.4"
 multibase = "0.9"
 multihash = "0.16"


### PR DESCRIPTION
> https://github.com/paritytech/jsonrpsee/pull/727

```
λ c update
    Updating crates.io index
    Updating git repository `https://github.com/chevdor/subwasm`
    Updating git repository `https://github.com/paritytech/jsonrpsee`
    Updating git repository `https://github.com/paritytech/substrate/`
error: failed to select a version for the requirement `jsonrpsee = "^0.9"`
candidate versions found which didn't match: 0.10.1
location searched: Git repository https://github.com/paritytech/jsonrpsee
required by package `wasm-loader v0.17.0 (https://github.com/chevdor/subwasm#045fdb4f)`
    ... which satisfies git dependency `wasm-loader` of package `runtime-overrides v0.1.0 (/root/Codes/darwinia-network/runtime-overrides)`
```

Suggest locking by tag. To prevent breaking downstream's `cargo update`.