### PR TITLE
Allow user overriding the Parachain Pallet Id

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -1,4 +1,8 @@
-# This is a sample env. Not needed if using defaults
+# This is a sample .env file. It is not needed if you
+# are using defaults if you want to use the default defined
+# below.
 
 # POLKADOT_HTTP=http://localhost:9933
 # POLKADOT_WS=ws://localhost:9944
+# PARACHAIN_PALLET_ID=0x01
+# AUTHORIZE_UPGRADE_PREFIX=0x03

--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ MacOS Homebrew users can use:
         -j, --json             Output as json
         -V, --version          Print version information
 
-By default, the ID for the Parachain pallet is expected to be `0x01`. This default behavior can be overriden by setting the `PARACHAIN_PALLET_ID_ENV` to the ID of your parachain pallet.
+By default, the ID for the Parachain pallet is expected to be `0x01` and the call ID for `authorize_upgrade` is expected to be `0x03`.
+This default behavior can be overriden by setting the `PARACHAIN_PALLET_ID` to the ID of your parachain pallet and the `AUTHORIZE_UPGRADE_PREFIX` to the ID of your choice.
 
 ### Command: meta
 
@@ -238,6 +239,19 @@ By default, the ID for the Parachain pallet is expected to be `0x01`. This defau
         -h, --help       Print help information
         -j, --json       Output as json
         -V, --version    Print version information
+
+### Environment variables
+
+In addition to the command line flags, you can also pass one of the following ENV variables:
+
+    # This is a sample .env file. It is not needed if you
+    # are using defaults if you want to use the default defined
+    # below.
+
+    # POLKADOT_HTTP=http://localhost:9933
+    # POLKADOT_WS=ws://localhost:9944
+    # PARACHAIN_PALLET_ID=0x01
+    # AUTHORIZE_UPGRADE_PREFIX=0x03
 
 ## Sample runs
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ MacOS Homebrew users can use:
 
 ### Command: --help
 
-    subwasm 0.17.0
+    subwasm 0.17.1
     chevdor <chevdor@gmail.com>:Wilfried Kopp <wilfried@parity.io
     `subwasm` allows fetching, parsing and calling some methods on WASM runtimes of Substrate based
     chains
@@ -92,7 +92,7 @@ MacOS Homebrew users can use:
 
 ### Command: get
 
-    subwasm-get 0.17.0
+    subwasm-get 0.17.1
     chevdor <chevdor@gmail.com>:Wilfried Kopp <wilfried@parity.io
     Get/Download the runtime wasm from a running node through rpc
 
@@ -122,7 +122,7 @@ MacOS Homebrew users can use:
 
 ### Command: info
 
-    subwasm-info 0.17.0
+    subwasm-info 0.17.1
     chevdor <chevdor@gmail.com>:Wilfried Kopp <wilfried@parity.io
     The `info` command returns summarized information about a runtime
 
@@ -145,9 +145,11 @@ MacOS Homebrew users can use:
         -j, --json             Output as json
         -V, --version          Print version information
 
+By default, the ID for the Parachain pallet is expected to be `0x01`. This default behavior can be overriden by setting the `PARACHAIN_PALLET_ID_ENV` to the ID of your parachain pallet.
+
 ### Command: meta
 
-    subwasm-metadata 0.17.0
+    subwasm-metadata 0.17.1
     chevdor <chevdor@gmail.com>:Wilfried Kopp <wilfried@parity.io
     Returns the metadata as a json object. You may also use the "meta" alias
 
@@ -176,7 +178,7 @@ MacOS Homebrew users can use:
 
 ### Command: diff
 
-    subwasm-diff 0.17.0
+    subwasm-diff 0.17.1
     chevdor <chevdor@gmail.com>:Wilfried Kopp <wilfried@parity.io
     Compare 2 runtimes
 
@@ -200,7 +202,7 @@ MacOS Homebrew users can use:
 
 ### Command: compress
 
-    subwasm-compress 0.17.0
+    subwasm-compress 0.17.1
     chevdor <chevdor@gmail.com>:Wilfried Kopp <wilfried@parity.io
     Compress a given runtime wasm file. You will get an error if you try compressing a runtime that is
     already compressed
@@ -219,7 +221,7 @@ MacOS Homebrew users can use:
 
 ### Command: decompress
 
-    subwasm-decompress 0.17.0
+    subwasm-decompress 0.17.1
     chevdor <chevdor@gmail.com>:Wilfried Kopp <wilfried@parity.io
     Decompress a given runtime wasm file. You may pass a runtime that is uncompressed already. In that
     case, you will get the same content as output. This is useful if you want to decompress "no matter

--- a/README_src.adoc
+++ b/README_src.adoc
@@ -85,6 +85,8 @@ include::doc/usage_get.adoc[]
 include::doc/usage_info.adoc[]
 ----
 
+NOTE: By default, the ID for the Parachain pallet is expected to be `0x01`. This default behavior can be overriden by setting the `PARACHAIN_PALLET_ID_ENV` to the ID of your parachain pallet.
+
 === Command: meta
 ----
 include::doc/usage_meta.adoc[]

--- a/README_src.adoc
+++ b/README_src.adoc
@@ -85,7 +85,8 @@ include::doc/usage_get.adoc[]
 include::doc/usage_info.adoc[]
 ----
 
-NOTE: By default, the ID for the Parachain pallet is expected to be `0x01`. This default behavior can be overriden by setting the `PARACHAIN_PALLET_ID_ENV` to the ID of your parachain pallet.
+NOTE: By default, the ID for the Parachain pallet is expected to be `0x01` and the call ID for `authorize_upgrade` is expected to be `0x03`.
+This default behavior can be overriden by setting the `PARACHAIN_PALLET_ID` to the ID of your parachain pallet and the `AUTHORIZE_UPGRADE_PREFIX` to the ID of your choice.
 
 === Command: meta
 ----
@@ -105,6 +106,14 @@ include::doc/usage_compress.adoc[]
 === Command: decompress
 ----
 include::doc/usage_decompress.adoc[]
+----
+
+=== Environment variables
+
+In addition to the command line flags, you can also pass one of the following ENV variables:
+
+----
+include::.env-sample[]
 ----
 
 == Sample runs

--- a/libs/substrate-runtime-proposal-hash/Cargo.toml
+++ b/libs/substrate-runtime-proposal-hash/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.17.0"
 blake2 = "0.10"
 codec = {version = "2.3", package = "parity-scale-codec"}
 frame-metadata = {version = "14", package = "frame-metadata", features = ["v12", "v13", "v14", "std"]}
-hex = "0.4"
+hex = "0.4.3"
 sc-executor = "0.9"
 sp-core = "3.0"
 sp-io = "3.0"


### PR DESCRIPTION
This PR adds support for the ENV: `PARACHAIN_PALLET_ID_ENV` and allows users overriding the default `0x01` by whatever ID of their choice.

`PARACHAIN_PALLET_ID_ENV` is to be passed in Hex as `0x32` for instance.