### PR TITLE
Add warning when compressed runtime is overall 2MB

### DIFF
--- a/lib/src/runtime_info.rs
+++ b/lib/src/runtime_info.rs
@@ -69,14 +69,16 @@ impl Display for RuntimeInfo {
 		let size_mb: f64 = self.size as f64 / 1024.0 / 1024.0;
 		let width_emoji = 1;
 		let width_title = 25;
+		const MAX_SIZE_COMPRESSED: f64 = 2_f64;
 
 		writeln!(
 			fmt,
-			"{:<width_emoji$} {:<width_title$} {:.3?} MB ({} bytes)",
+			"{:<width_emoji$} {:<width_title$} {:.3?} MB ({} bytes) {warning}",
 			"🏋️ ",
 			"Runtime size:",
 			size_mb,
-			self.size.to_formatted_string(&Locale::en)
+			self.size.to_formatted_string(&Locale::en),
+			warning = if size_mb >= MAX_SIZE_COMPRESSED { "⚠️ HEAVY" } else { "" }
 		)?;
 		if self.compression.compressed() {
 			writeln!(


### PR DESCRIPTION
fix #37

Here is a demo with a limit at 1MB:
<img width="1026" alt="image" src="https://user-images.githubusercontent.com/738724/177564031-978b846f-8b5e-4265-a769-e54da506b32d.png">

