### PR TITLE
feat: add option to output metadata to a file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ data
 .env
 scripts/out
 *.gz
+metadata.*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3210,6 +3210,7 @@ dependencies = [
  "calm_io",
  "color-eyre",
  "frame-metadata",
+ "hex",
  "ipfs-hasher",
  "log",
  "num-format",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,25 +340,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
-name = "calm_io"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ea0608700fe42d90ec17ad0f86335cf229b67df2e34e7f463e8241ce7b8fa5f"
-dependencies = [
- "calmio_filters",
-]
-
-[[package]]
-name = "calmio_filters"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "846501f4575cd66766a40bb7ab6d8e960adc7eb49f753c8232bd8e0e09cf6ca2"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
 name = "cc"
 version = "1.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3207,7 +3188,6 @@ dependencies = [
 name = "subwasmlib"
 version = "0.18.0"
 dependencies = [
- "calm_io",
  "color-eyre",
  "frame-metadata",
  "hex",

--- a/README.md
+++ b/README.md
@@ -63,209 +63,143 @@ MacOS Homebrew users can use:
 
 ### Command: --help
 
-    subwasm 0.18.0
-    chevdor <chevdor@gmail.com>:Wilfried Kopp <wilfried@parity.io
-    `subwasm` allows fetching, parsing and calling some methods on WASM runtimes of Substrate based
-    chains
+    `subwasm` allows fetching, parsing and calling some methods on WASM runtimes of Substrate based chains
 
-    USAGE:
-        subwasm [OPTIONS] <SUBCOMMAND>
+    Usage: subwasm [OPTIONS] <COMMAND>
 
-    OPTIONS:
-        -h, --help       Print help information
-        -j, --json       Output as json
-        -q, --quiet      Less output
-        -V, --version    Print version information
+    Commands:
+      get         Get/Download the runtime wasm from a running node through rpc
+      info        The `info` command returns summarized information about a runtime
+      version     The `version` command returns summarized information about the versions of a runtime
+      metadata    Returns the metadata as a json object. You may also use the "meta" alias
+      diff        Compare 2 runtimes
+      compress    Compress a given runtime wasm file. You will get an error if you try compressing a runtime that is already compressed
+      decompress  Decompress a given runtime wasm file. You may pass a runtime that is uncompressed already. In that case, you will get the same content as output. This is useful if you want to decompress "no matter what" and don't really know whether the input will be compressed or not
+      help        Print this message or the help of the given subcommand(s)
 
-    SUBCOMMANDS:
-        compress      Compress a given runtime wasm file. You will get an error if you try
-                          compressing a runtime that is already compressed
-        decompress    Decompress a given runtime wasm file. You may pass a runtime that is
-                          uncompressed already. In that case, you will get the same content as output.
-                          This is useful if you want to decompress "no matter what" and don't really
-                          know whether the input will be compressed or not
-        diff          Compare 2 runtimes
-        get           Get/Download the runtime wasm from a running node through rpc
-        help          Print this message or the help of the given subcommand(s)
-        info          The `info` command returns summarized information about a runtime
-        metadata      Returns the metadata as a json object. You may also use the "meta" alias
-        version       The `version` command returns summarized information about the versions of a
-                          runtime
+    Options:
+      -j, --json     Output as json
+      -q, --quiet    Less output
+      -h, --help     Print help information
+      -V, --version  Print version information
 
 ### Command: get
 
-    subwasm-get 0.18.0
-    chevdor <chevdor@gmail.com>:Wilfried Kopp <wilfried@parity.io
     Get/Download the runtime wasm from a running node through rpc
 
-    USAGE:
-        subwasm get [OPTIONS] [URL]
+    Usage: subwasm get [OPTIONS] [URL]
 
-    ARGS:
-        <URL>    The node url including (mandatory) the port number. Example: ws://localhost:9944 or
-                 http://localhost:9933 [default: http://localhost:9933]
+    Arguments:
+      [URL]  The node url including (mandatory) the port number. Example: ws://localhost:9944 or http://localhost:9933 [default: http://localhost:9933]
 
-    OPTIONS:
-        -b, --block <BLOCK>      The optional block where to fetch the runtime. That allows fetching
-                                 older runtimes but you will need to connect to archive nodes.
-                                 Currently, you must pass a block hash. Passing the block numbers is not
-                                 supported
-            --chain <CHAIN>      Provide the name of a chain and a random url amongst a list of known
-                                 nodes will be used. If you pass a valid --chain, --url will be ignored
-                                 --chain local = http://localhost:9933
-        -h, --help               Print help information
-        -j, --json               Output as json
-        -o, --output <OUTPUT>    You may specifiy the output filename where the runtime will be saved.
-                                 If not provided, we will figure out an appropriate default name based
-                                 on a counter: runtime_NNN.wasm where NNN is incrementing to make sure
-                                 you do not override previous runtime. If you specify an existing file
-                                 as output, it will be overwritten
-        -V, --version            Print version information
+    Options:
+          --chain <CHAIN>    Provide the name of a chain and a random url amongst a list of known nodes will be used. If you pass a valid --chain, --url will be ignored --chain local = http://localhost:9933
+      -j, --json             Output as json
+      -b, --block <BLOCK>    The optional block where to fetch the runtime. That allows fetching older runtimes but you will need to connect to archive nodes. Currently, you must pass a block hash. Passing the block numbers is not supported
+      -o, --output <OUTPUT>  You may specifiy the output filename where the runtime will be saved. If not provided, we will figure out an appropriate default name based on a counter: runtime_NNN.wasm where NNN is incrementing to make sure you do not override previous runtime. If you specify an existing file as output, it will be overwritten
+      -h, --help             Print help information
+      -V, --version          Print version information
 
 ### Command: info
 
-    subwasm-info 0.18.0
-    chevdor <chevdor@gmail.com>:Wilfried Kopp <wilfried@parity.io
     The `info` command returns summarized information about a runtime
 
-    USAGE:
-        subwasm info [OPTIONS] [SOURCE]
+    Usage: subwasm info [OPTIONS] [SOURCE]
 
-    ARGS:
-        <SOURCE>    The wasm file to load. It can be a path on your local filesystem such as
-                    /tmp/runtime.wasm or a node url such as http://localhost:9933 or
-                    ws://localhost:9944 [default: runtime_000.wasm]
+    Arguments:
+      [SOURCE]  The wasm file to load. It can be a path on your local filesystem such as /tmp/runtime.wasm or a node url such as http://localhost:9933 or ws://localhost:9944 [default: runtime_000.wasm]
 
-    OPTIONS:
-        -b, --block <BLOCK>    The optional block where to fetch the runtime. That allows fetching older
-                               runtimes but you will need to connect to archive nodes. Currently, you
-                               must pass a block hash. Passing the block numbers is not supported
-            --chain <CHAIN>    Provide the name of a chain and a random url amongst a list of known
-                               nodes will be used. If you pass a valid --chain, --url will be ignored
-                               --chain local = http://localhost:9933
-        -h, --help             Print help information
-        -j, --json             Output as json
-        -V, --version          Print version information
+    Options:
+          --chain <CHAIN>  Provide the name of a chain and a random url amongst a list of known nodes will be used. If you pass a valid --chain, --url will be ignored --chain local = http://localhost:9933
+      -j, --json           Output as json
+      -b, --block <BLOCK>  The optional block where to fetch the runtime. That allows fetching older runtimes but you will need to connect to archive nodes. Currently, you must pass a block hash. Passing the block numbers is not supported
+      -h, --help           Print help information
+      -V, --version        Print version information
 
 By default, the ID for the Parachain pallet is expected to be `0x01` and the call ID for `authorize_upgrade` is expected to be `0x03`.
 This default behavior can be overriden by setting the `PARACHAIN_PALLET_ID` to the ID of your parachain pallet and the `AUTHORIZE_UPGRADE_PREFIX` to the ID of your choice.
 
 ### Command: version
 
-    subwasm-version 0.18.0
-    chevdor <chevdor@gmail.com>:Wilfried Kopp <wilfried@parity.io
     The `version` command returns summarized information about the versions of a runtime
 
-    USAGE:
-        subwasm version [OPTIONS] [SOURCE]
+    Usage: subwasm version [OPTIONS] [SOURCE]
 
-    ARGS:
-        <SOURCE>    The wasm file to load. It can be a path on your local filesystem such as
-                    /tmp/runtime.wasm or a node url such as http://localhost:9933 or
-                    ws://localhost:9944 [default: runtime_000.wasm]
+    Arguments:
+      [SOURCE]  The wasm file to load. It can be a path on your local filesystem such as /tmp/runtime.wasm or a node url such as http://localhost:9933 or ws://localhost:9944 [default: runtime_000.wasm]
 
-    OPTIONS:
-        -b, --block <BLOCK>    The optional block where to fetch the runtime. That allows fetching older
-                               runtimes but you will need to connect to archive nodes. Currently, you
-                               must pass a block hash. Passing the block numbers is not supported
-            --chain <CHAIN>    Provide the name of a chain and a random url amongst a list of known
-                               nodes will be used. If you pass a valid --chain, --url will be ignored
-                               --chain local = http://localhost:9933
-        -h, --help             Print help information
-        -j, --json             Output as json
-        -V, --version          Print version information
+    Options:
+          --chain <CHAIN>  Provide the name of a chain and a random url amongst a list of known nodes will be used. If you pass a valid --chain, --url will be ignored --chain local = http://localhost:9933
+      -j, --json           Output as json
+      -b, --block <BLOCK>  The optional block where to fetch the runtime. That allows fetching older runtimes but you will need to connect to archive nodes. Currently, you must pass a block hash. Passing the block numbers is not supported
+      -h, --help           Print help information
+      -V, --version        Print version information
 
 ### Command: meta
 
-    subwasm-metadata 0.18.0
-    chevdor <chevdor@gmail.com>:Wilfried Kopp <wilfried@parity.io
     Returns the metadata as a json object. You may also use the "meta" alias
 
-    USAGE:
-        subwasm metadata [OPTIONS] [SOURCE]
+    Usage: subwasm metadata [OPTIONS] [SOURCE]
 
-    ARGS:
-        <SOURCE>    The wasm file to load. It can be a path on your local filesystem such as
-                    /tmp/runtime.wasm or a node url such as http://localhost:9933 or
-                    ws://localhost:9944 [default: runtime_000.wasm]
+    Arguments:
+      [SOURCE]  The wasm file to load. It can be a path on your local filesystem such as /tmp/runtime.wasm or a node url such as http://localhost:9933 or ws://localhost:9944 [default: runtime_000.wasm]
 
-    OPTIONS:
-        -b, --block <BLOCK>      The optional block where to fetch the runtime. That allows fetching
-                                 older runtimes but you will need to connect to archive nodes.
-                                 Currently, you must pass a block hash. Passing the block numbers is not
-                                 supported
-            --chain <CHAIN>      Provide the name of a chain and a random url amongst a list of known
-                                 nodes will be used. If you pass a valid --chain, --url will be ignored
-                                 --chain local = http://localhost:9933
-        -h, --help               Print help information
-        -j, --json               Output as json
-        -m, --module <MODULE>    Without this flag, the metadata command display the list of all
-                                 modules. Using this flag, you will only see the module of your choice
-                                 and a few details about it
-        -V, --version            Print version information
+    Options:
+          --chain <CHAIN>    Provide the name of a chain and a random url amongst a list of known nodes will be used. If you pass a valid --chain, --url will be ignored --chain local = http://localhost:9933
+      -j, --json             Output as json
+      -m, --module <MODULE>  Without this flag, the metadata command display the list of all modules. Using this flag, you will only see the module of your choice and a few details about it
+      -b, --block <BLOCK>    The optional block where to fetch the runtime. That allows fetching older runtimes but you will need to connect to archive nodes. Currently, you must pass a block hash. Passing the block numbers is not supported
+      -f, --format <FORMAT>  You may specifiy the output format. One of "human", "scale", "json", "json+scale", "hex+scale" [default: human]
+      -o, --output <OUTPUT>  You may specifiy the output filename where the metadata will be saved. Alternatively, you may use `auto` and an appropriate name will be generated according to the `format` your chose
+      -h, --help             Print help information
+      -V, --version          Print version information
 
 ### Command: diff
 
-    subwasm-diff 0.18.0
-    chevdor <chevdor@gmail.com>:Wilfried Kopp <wilfried@parity.io
     Compare 2 runtimes
 
-    USAGE:
-        subwasm diff [OPTIONS] [ARGS]
+    Usage: subwasm diff [OPTIONS] [SRC_A] [SRC_B]
 
-    ARGS:
-        <SRC_A>    The first source [default: runtime_000.wasm]
-        <SRC_B>    The second source [default: runtime_001.wasm]
+    Arguments:
+      [SRC_A]  The first source [default: runtime_000.wasm]
+      [SRC_B]  The second source [default: runtime_001.wasm]
 
-    OPTIONS:
-        -a, --chain-a <CHAIN_A>    Provide the name of a chain and a random url amongst a list of known
-                                   nodes will be used. If you pass a valid --chain, --url will be
-                                   ignored --chain local = http://localhost:9933
-        -b, --chain-b <CHAIN_B>    Provide the name of a chain and a random url amongst a list of known
-                                   nodes will be used. If you pass a valid --chain, --url will be
-                                   ignored --chain local = http://localhost:9933
-        -h, --help                 Print help information
-        -j, --json                 Output as json
-        -V, --version              Print version information
+    Options:
+      -a, --chain-a <CHAIN_A>  Provide the name of a chain and a random url amongst a list of known nodes will be used. If you pass a valid --chain, --url will be ignored --chain local = http://localhost:9933
+      -j, --json               Output as json
+      -b, --chain-b <CHAIN_B>  Provide the name of a chain and a random url amongst a list of known nodes will be used. If you pass a valid --chain, --url will be ignored --chain local = http://localhost:9933
+      -h, --help               Print help information
+      -V, --version            Print version information
 
 ### Command: compress
 
-    subwasm-compress 0.18.0
-    chevdor <chevdor@gmail.com>:Wilfried Kopp <wilfried@parity.io
-    Compress a given runtime wasm file. You will get an error if you try compressing a runtime that is
-    already compressed
+    Compress a given runtime wasm file. You will get an error if you try compressing a runtime that is already compressed
 
-    USAGE:
-        subwasm compress [OPTIONS] <INPUT> <OUTPUT>
+    Usage: subwasm compress [OPTIONS] <INPUT> <OUTPUT>
 
-    ARGS:
-        <INPUT>     The path of uncompressed wasm file to load
-        <OUTPUT>    The path of the file where the compressed runtime will be stored
+    Arguments:
+      <INPUT>   The path of uncompressed wasm file to load
+      <OUTPUT>  The path of the file where the compressed runtime will be stored
 
-    OPTIONS:
-        -h, --help       Print help information
-        -j, --json       Output as json
-        -V, --version    Print version information
+    Options:
+      -j, --json     Output as json
+      -h, --help     Print help information
+      -V, --version  Print version information
 
 ### Command: decompress
 
-    subwasm-decompress 0.18.0
-    chevdor <chevdor@gmail.com>:Wilfried Kopp <wilfried@parity.io
-    Decompress a given runtime wasm file. You may pass a runtime that is uncompressed already. In that
-    case, you will get the same content as output. This is useful if you want to decompress "no matter
-    what" and don't really know whether the input will be compressed or not
+    Decompress a given runtime wasm file. You may pass a runtime that is uncompressed already. In that case, you will get the same content as output. This is useful if you want to decompress "no matter what" and don't really know whether the input will be compressed or not
 
-    USAGE:
-        subwasm decompress [OPTIONS] <INPUT> <OUTPUT>
+    Usage: subwasm decompress [OPTIONS] <INPUT> <OUTPUT>
 
-    ARGS:
-        <INPUT>     The path of the compressed or uncompressed wasm file to load
-        <OUTPUT>    The path of the file where the uncompressed runtime will be stored
+    Arguments:
+      <INPUT>   The path of the compressed or uncompressed wasm file to load
+      <OUTPUT>  The path of the file where the uncompressed runtime will be stored
 
-    OPTIONS:
-        -h, --help       Print help information
-        -j, --json       Output as json
-        -V, --version    Print version information
+    Options:
+      -j, --json     Output as json
+      -h, --help     Print help information
+      -V, --version  Print version information
 
 ### Environment variables
 
@@ -321,10 +255,9 @@ Here is a list of other projects allowing to get the raw metadata through a rpc 
 -   [PolkadotJS](https://github.com/polkadot-js/apps) from Jaco / Parity
 
 -   [subsee](https://github.com/ascjones/subsee) from Andrew / Parity
+
 -   [substrate-api-client](https://github.com/scs/substrate-api-client) from SCS
 
 -   [subxt](https://github.com/paritytech/substrate-subxt) from Parity
 
 All those alternatives require a running node and access it via jsonrpc.
-
--   [smoldot](https://github.com/paritytech/smoldot) light client from Parity allows to [get metadata](https://github.com/AcalaNetwork/chopsticks/pull/80) from wasm

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -58,7 +58,7 @@ fn main() -> color_eyre::Result<()> {
 			info!("⏱️  Loading WASM from {:?}", &source);
 			let subwasm = Subwasm::new(&source);
 
-			let fmt: OutputFormat = meta_opts.format.unwrap_or("human".into()).into();
+			let fmt: OutputFormat = meta_opts.format.unwrap_or_else(|| "human".into()).into();
 			let mut output = meta_opts.output;
 			if let Some(out) = &output {
 				if out.is_empty() {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -69,7 +69,7 @@ fn main() -> color_eyre::Result<()> {
 
 			let mut output = meta_opts.output;
 			if let Some(out) = &output {
-				if out.is_empty() {
+				if out.is_empty() || out == "auto" {
 					match fmt {
 						OutputFormat::Human => output = Some("metadata.txt".into()),
 						OutputFormat::Json => output = Some("metadata.json".into()),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -58,6 +58,12 @@ fn main() -> color_eyre::Result<()> {
 
 			if let Some(filter) = meta_opts.module {
 				subwasm.display_module(filter);
+			} else if let Some(output) = meta_opts.output {
+				if opts.json {
+					subwasm.write_metadata_json(&output);
+				}else{
+					subwasm.write_metadata_scale(&output);
+				}
 			} else if opts.json {
 				subwasm.display_metadata_json()
 			} else {

--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -132,6 +132,10 @@ pub struct MetaOpts {
 	/// Currently, you must pass a block hash. Passing the block numbers is not supported.
 	#[clap(short, long)]
 	pub block: Option<String>, // TODO: can do better...
+
+	/// You may specifiy the output filename where the metadata will be saved.
+	#[clap(short, long)]
+	pub output: Option<String>,
 }
 
 /// Compare 2 runtimes

--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -133,6 +133,10 @@ pub struct MetaOpts {
 	#[clap(short, long)]
 	pub block: Option<String>, // TODO: can do better...
 
+	/// You may specifiy the output format. One of "human", "scale", "json", "json+scale", "hex+scale"
+	#[clap(long, short, default_value = "human")]
+	pub format: Option<String>,
+
 	/// You may specifiy the output filename where the metadata will be saved.
 	#[clap(short, long)]
 	pub output: Option<String>,

--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -138,6 +138,7 @@ pub struct MetaOpts {
 	pub format: Option<String>,
 
 	/// You may specifiy the output filename where the metadata will be saved.
+	/// Alternatively, you may use `auto` and an appropriate name will be generated according to the `format` your chose.
 	#[clap(short, long)]
 	pub output: Option<String>,
 }

--- a/cli/tests/test.rs
+++ b/cli/tests/test.rs
@@ -32,7 +32,7 @@ mod cli_tests {
 		fn it_gets_a_runtime() {
 			let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
 
-			let assert = cmd.args(&["get", "--output", "runtime.wasm", "wss://rpc.polkadot.io:443"]).assert();
+			let assert = cmd.args(["get", "--output", "runtime.wasm", "wss://rpc.polkadot.io:443"]).assert();
 			assert.success().code(0);
 			assert!(Path::new("runtime.wasm").exists());
 		}
@@ -41,7 +41,7 @@ mod cli_tests {
 		fn it_fails_on_bad_chain() {
 			let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
 
-			let assert = cmd.args(&["get", "--chain", "foobar"]).assert();
+			let assert = cmd.args(["get", "--chain", "foobar"]).assert();
 			assert.failure().code(101);
 		}
 	}
@@ -53,11 +53,11 @@ mod cli_tests {
 		#[test]
 		fn it_shows_metadata() {
 			let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
-			let assert = cmd.args(&["get", "wss://rpc.polkadot.io:443", "--output", "runtime.wasm"]).assert();
+			let assert = cmd.args(["get", "wss://rpc.polkadot.io:443", "--output", "runtime.wasm"]).assert();
 			assert.success().code(0);
 
 			let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
-			let assert = cmd.args(&["meta", "runtime.wasm"]).assert();
+			let assert = cmd.args(["meta", "runtime.wasm"]).assert();
 			assert.success().code(0);
 		}
 	}
@@ -69,27 +69,27 @@ mod cli_tests {
 		#[test]
 		fn it_does_basic_compress_decompress() {
 			let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
-			let assert = cmd.args(&["get", "wss://rpc.polkadot.io:443", "--output", "compressed.wasm"]).assert();
+			let assert = cmd.args(["get", "wss://rpc.polkadot.io:443", "--output", "compressed.wasm"]).assert();
 			assert.success().code(0);
 
 			let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
-			cmd.args(&["decompress", "compressed.wasm", "decompressed.wasm"]).assert().success().code(0);
+			cmd.args(["decompress", "compressed.wasm", "decompressed.wasm"]).assert().success().code(0);
 
 			let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
-			cmd.args(&["compress", "decompressed.wasm", "new_compressed.wasm"]).assert().success().code(0);
+			cmd.args(["compress", "decompressed.wasm", "new_compressed.wasm"]).assert().success().code(0);
 		}
 
 		#[test]
 		fn it_does_decompress_on_already() {
 			let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
-			let assert = cmd.args(&["get", "wss://rpc.polkadot.io:443", "--output", "compressed.wasm"]).assert();
+			let assert = cmd.args(["get", "wss://rpc.polkadot.io:443", "--output", "compressed.wasm"]).assert();
 			assert.success().code(0);
 
 			let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
-			cmd.args(&["decompress", "compressed.wasm", "decompressed.wasm"]).assert().success().code(0);
+			cmd.args(["decompress", "compressed.wasm", "decompressed.wasm"]).assert().success().code(0);
 
 			let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
-			cmd.args(&["decompress", "decompressed.wasm", "new_decompressed.wasm"]).assert().success().code(0);
+			cmd.args(["decompress", "decompressed.wasm", "new_decompressed.wasm"]).assert().success().code(0);
 		}
 	}
 }

--- a/doc/usage_meta.adoc
+++ b/doc/usage_meta.adoc
@@ -11,6 +11,6 @@ Options:
   -m, --module <MODULE>  Without this flag, the metadata command display the list of all modules. Using this flag, you will only see the module of your choice and a few details about it
   -b, --block <BLOCK>    The optional block where to fetch the runtime. That allows fetching older runtimes but you will need to connect to archive nodes. Currently, you must pass a block hash. Passing the block numbers is not supported
   -f, --format <FORMAT>  You may specifiy the output format. One of "human", "scale", "json", "json+scale", "hex+scale" [default: human]
-  -o, --output <OUTPUT>  You may specifiy the output filename where the metadata will be saved. Alternatively, you may use `auto` and an appropriate name will be generated according to the `format` you choose
+  -o, --output <OUTPUT>  You may specifiy the output filename where the metadata will be saved. Alternatively, you may use `auto` and an appropriate name will be generated according to the `format` your chose
   -h, --help             Print help information
   -V, --version          Print version information

--- a/doc/usage_meta.adoc
+++ b/doc/usage_meta.adoc
@@ -11,6 +11,6 @@ Options:
   -m, --module <MODULE>  Without this flag, the metadata command display the list of all modules. Using this flag, you will only see the module of your choice and a few details about it
   -b, --block <BLOCK>    The optional block where to fetch the runtime. That allows fetching older runtimes but you will need to connect to archive nodes. Currently, you must pass a block hash. Passing the block numbers is not supported
   -f, --format <FORMAT>  You may specifiy the output format. One of "human", "scale", "json", "json+scale", "hex+scale" [default: human]
-  -o, --output <OUTPUT>  You may specifiy the output filename where the metadata will be saved
+  -o, --output <OUTPUT>  You may specifiy the output filename where the metadata will be saved. Alternatively, you may use `auto` and an appropriate name will be generated according to the `format` your chose
   -h, --help             Print help information
   -V, --version          Print version information

--- a/doc/usage_meta.adoc
+++ b/doc/usage_meta.adoc
@@ -11,6 +11,6 @@ Options:
   -m, --module <MODULE>  Without this flag, the metadata command display the list of all modules. Using this flag, you will only see the module of your choice and a few details about it
   -b, --block <BLOCK>    The optional block where to fetch the runtime. That allows fetching older runtimes but you will need to connect to archive nodes. Currently, you must pass a block hash. Passing the block numbers is not supported
   -f, --format <FORMAT>  You may specifiy the output format. One of "human", "scale", "json", "json+scale", "hex+scale" [default: human]
-  -o, --output <OUTPUT>  You may specifiy the output filename where the metadata will be saved. Alternatively, you may use `auto` and an appropriate name will be generated according to the `format` your chose
+  -o, --output <OUTPUT>  You may specifiy the output filename where the metadata will be saved. Alternatively, you may use `auto` and an appropriate name will be generated according to the `format` you choose
   -h, --help             Print help information
   -V, --version          Print version information

--- a/doc/usage_meta.adoc
+++ b/doc/usage_meta.adoc
@@ -10,5 +10,7 @@ Options:
   -j, --json             Output as json
   -m, --module <MODULE>  Without this flag, the metadata command display the list of all modules. Using this flag, you will only see the module of your choice and a few details about it
   -b, --block <BLOCK>    The optional block where to fetch the runtime. That allows fetching older runtimes but you will need to connect to archive nodes. Currently, you must pass a block hash. Passing the block numbers is not supported
+  -f, --format <FORMAT>  You may specifiy the output format. One of "human", "scale", "json", "json+scale", "hex+scale" [default: human]
+  -o, --output <OUTPUT>  You may specifiy the output filename where the metadata will be saved
   -h, --help             Print help information
   -V, --version          Print version information

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -18,7 +18,6 @@ repository = "https://github.com/chevdor/subwasm"
 version = "0.18.0"
 
 [dependencies]
-calm_io = "0.1"
 color-eyre = "0.6"
 frame-metadata = { version = "15", package = "frame-metadata", features = [
     "v12",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -39,3 +39,4 @@ substrate-differ = { version = "0.18.0", path = "../libs/substrate-differ" }
 wasm-loader = { version = "0.18.0", path = "../libs/wasm-loader" }
 wasm-testbed = { version = "0.18.0", path = "../libs/wasm-testbed" }
 sp-version = { tag = "monthly-2022-07", git = "https://github.com/paritytech/substrate" }
+hex = "0.4"

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -17,6 +17,7 @@ mod subwasm;
 mod types;
 pub use chain_info::*;
 use log::{debug, info};
+pub use metadata_wrapper::OutputFormat;
 pub use runtime_info::*;
 pub use subwasm::*;
 pub use types::*;

--- a/lib/src/macros.rs
+++ b/lib/src/macros.rs
@@ -1,6 +1,6 @@
 #[macro_export]
-macro_rules! display_module {
-	($modules: expr, $filter: ident) => {
+macro_rules! write_module {
+	($modules: expr, $filter: ident, $out: ident) => {
 		let meta = $modules
 			.iter()
 			.find(|module| {
@@ -9,29 +9,29 @@ macro_rules! display_module {
 			})
 			.expect("pallet not found in metadata");
 
-		println!("Module {:02}: {}", meta.index, convert(&meta.name));
+		write!($out, "Module {:02}: {}\n", meta.index, convert(&meta.name));
 
-		println!("🤙 Calls:");
+		write!($out, "🤙 Calls:\n");
 		if let Some(item) = meta.calls.as_ref() {
 			let calls = convert(&item);
 			for call in calls {
-				println!("  - {}", convert(&call.name));
+				write!($out, "  - {}\n", convert(&call.name));
 			}
 		}
 
-		println!("📢 Events:");
+		write!($out, "📢 Events:\n");
 		if let Some(item) = meta.event.as_ref() {
 			let events = convert(&item);
 			for event in events {
-				println!("  - {}", convert(&event.name));
+				write!($out, "  - {}\n", convert(&event.name));
 			}
 		}
 	};
 }
 
 #[macro_export]
-macro_rules! display_v14_meta {
-	($v14: expr, $meta: expr, $type: ident) => {
+macro_rules! write_v14_meta {
+	($v14: expr, $meta: expr, $type: ident, $out: ident) => {
 		if let Some(metadata) = &$meta.$type {
 			let type_id = metadata.ty.id();
 			// log::debug!("type_id: {:?}", type_id);
@@ -41,11 +41,25 @@ macro_rules! display_v14_meta {
 			match type_info.type_def() {
 				scale_info::TypeDef::Variant(v) => {
 					for variant in v.variants() {
-						println!("- {:?}: {}", variant.index(), variant.name());
+						write!($out, "- {:?}: {}\n", variant.index(), variant.name());
 					}
 				}
 				o => panic!("Unsupported variant: {:?}", o),
 			}
 		}
+	};
+}
+
+#[macro_export]
+macro_rules! display_module {
+	($modules: expr, $filter: ident) => {
+		crate::write_module!($modules, $filter, std::io::stdout());
+	};
+}
+
+#[macro_export]
+macro_rules! display_v14_meta {
+	($v14: expr, $meta: expr, $type: ident) => {
+		crate::write_v14_meta!($v14, $meta, $type, std::io::stdout());
 	};
 }

--- a/lib/src/macros.rs
+++ b/lib/src/macros.rs
@@ -53,13 +53,13 @@ macro_rules! write_v14_meta {
 #[macro_export]
 macro_rules! display_module {
 	($modules: expr, $filter: ident) => {
-		crate::write_module!($modules, $filter, std::io::stdout());
+		$crate::write_module!($modules, $filter, std::io::stdout());
 	};
 }
 
 #[macro_export]
 macro_rules! display_v14_meta {
 	($v14: expr, $meta: expr, $type: ident) => {
-		crate::write_v14_meta!($v14, $meta, $type, std::io::stdout());
+		$crate::write_v14_meta!($v14, $meta, $type, std::io::stdout());
 	};
 }

--- a/lib/src/macros.rs
+++ b/lib/src/macros.rs
@@ -1,14 +1,16 @@
 #[macro_export]
 macro_rules! write_module {
 	($modules: expr, $filter: ident, $out: ident) => {
-		|| -> Result<(), std::io::Error> {
+		|| -> color_eyre::Result<()> {
+			use color_eyre::eyre::eyre;
+
 			let meta = $modules
 				.iter()
 				.find(|module| {
 					let name_str = convert(&module.name).to_lowercase();
 					name_str == $filter.to_lowercase()
 				})
-				.expect("pallet not found in metadata");
+				.ok_or_else(|| eyre!("pallet not found in metadata"))?;
 
 			writeln!($out, "Module {:02}: {}", meta.index, convert(&meta.name))?;
 
@@ -35,7 +37,9 @@ macro_rules! write_module {
 #[macro_export]
 macro_rules! write_v14_meta {
 	($v14: expr, $meta: expr, $type: ident, $out: ident) => {
-		|| -> Result<(), Box<dyn std::error::Error>> {
+		|| -> color_eyre::Result<()> {
+			use color_eyre::eyre::eyre;
+
 			if let Some(metadata) = &$meta.$type {
 				let type_id = metadata.ty.id();
 				// log::debug!("type_id: {:?}", type_id);
@@ -48,10 +52,10 @@ macro_rules! write_v14_meta {
 							write!($out, "- {:?}: {}\n", variant.index(), variant.name())?;
 						}
 					}
-					o => return Err(format!("Unsupported variant: {:?}", o).into()),
+					o => return Err(eyre!("Unsupported variant: {:?}", o)),
 				}
 			} else {
-				return Err(format!("No metadata found\n").into());
+				return Err(eyre!("No metadata found\n"));
 			}
 			Ok(())
 		}()?

--- a/lib/src/metadata_wrapper.rs
+++ b/lib/src/metadata_wrapper.rs
@@ -28,8 +28,8 @@ impl<S: AsRef<str>> From<S> for OutputFormat {
 			"human" => OutputFormat::Human,
 			"json" => OutputFormat::Json,
 			"scale" => OutputFormat::Scale,
-			"hex+scale" => OutputFormat::HexScale,
-			"json+scale" => OutputFormat::JsonScale,
+			"hex+scale" | "scale+hex" => OutputFormat::HexScale,
+			"json+scale" | "scale+json" => OutputFormat::JsonScale,
 			_ => panic!("Unknown output format"),
 		}
 	}
@@ -78,7 +78,7 @@ impl<'a> MetadataWrapper<'a> {
 					let encoded = self.0.encode();
 					let hex = format!("0x{}", hex::encode(encoded));
 					let json = serde_json::to_string_pretty(&serde_json::json!({ "result": hex }))?;
-					write!(out, "{}", json)?;
+					write!(out, "{json}")?;
 				}
 			}
 		}

--- a/lib/src/metadata_wrapper.rs
+++ b/lib/src/metadata_wrapper.rs
@@ -98,14 +98,14 @@ impl<'a> MetadataWrapper<'a> {
 				let mut modules = convert(&v12.modules).clone();
 				modules.sort_by(|a, b| a.index.cmp(&b.index));
 				modules.iter().try_for_each(|module| -> std::io::Result<()> {
-					write!(out, " - {:02}: {}\n", module.index, convert(&module.name))
+					writeln!(out, " - {:02}: {}", module.index, convert(&module.name))
 				})?;
 			}
 			RuntimeMetadata::V13(v13) => {
 				let mut modules = convert(&v13.modules).clone();
 				modules.sort_by(|a, b| a.index.cmp(&b.index));
 				modules.iter().try_for_each(|module| -> std::io::Result<()> {
-					write!(out, " - {:02}: {}\n", module.index, convert(&module.name))
+					writeln!(out, " - {:02}: {}", module.index, convert(&module.name))
 				})?;
 			}
 			RuntimeMetadata::V14(v14) => {
@@ -113,7 +113,7 @@ impl<'a> MetadataWrapper<'a> {
 				// pallets.sort_by(|a,b| a.index.cmp(&b.index));
 				pallets.sort_by_key(|p| p.index);
 				pallets.iter().try_for_each(|pallet| -> std::io::Result<()> {
-					write!(out, " - {:02}: {}\n", pallet.index, pallet.name)
+					writeln!(out, " - {:02}: {}", pallet.index, pallet.name)
 				})?;
 			}
 			_ => panic!("Runtime not supported. Subwasm supports V12 and above."),
@@ -142,27 +142,27 @@ impl<'a> MetadataWrapper<'a> {
 					})
 					.expect("pallet not found in metadata");
 
-				write!(out, "Module {:02}: {}\n", meta.index, &meta.name)?;
+				writeln!(out, "Module {:02}: {}", meta.index, &meta.name)?;
 
-				write!(out, "🤙 Calls:\n")?;
+				writeln!(out, "🤙 Calls:")?;
 				write_v14_meta!(v14, meta, calls, out);
 
-				write!(out, "📢 Events:\n")?;
+				writeln!(out, "📢 Events:")?;
 				write_v14_meta!(v14, meta, event, out);
 
-				write!(out, "⛔️ Errors:\n")?;
+				writeln!(out, "⛔️ Errors:")?;
 				write_v14_meta!(v14, meta, error, out);
 
-				write!(out, "📦 Storage:\n")?;
+				writeln!(out, "📦 Storage:")?;
 				if let Some(meta) = &meta.storage {
 					for entry in &meta.entries {
-						write!(out, "- {}\n", entry.name)?;
+						writeln!(out, "- {}", entry.name)?;
 					}
 				}
 
-				write!(out, "💎 Constants:\n")?;
+				writeln!(out, "💎 Constants:")?;
 				for item in &meta.constants {
-					write!(out, "- {}\n", item.name)?;
+					writeln!(out, "- {}", item.name)?;
 				}
 			}
 			_ => panic!("Runtime not supported\n"),

--- a/lib/src/metadata_wrapper.rs
+++ b/lib/src/metadata_wrapper.rs
@@ -1,45 +1,136 @@
+use std::io::Write;
+
 use frame_metadata::RuntimeMetadata;
 use log::debug;
+use scale_info::scale::Encode;
 
-use crate::{convert::convert, display_module, display_v14_meta};
+use crate::{convert::convert, write_module, write_v14_meta};
+
+/// The output format for the metadata
+#[derive(Debug, Clone, Copy)]
+pub enum OutputFormat {
+	/// Output the metadata in a human readable format
+	Human,
+	/// Output the metadata in json format
+	Json,
+	/// Output the metadata in raw scale format
+	Scale,
+	/// Output the metadata in hex encoded scale format
+	HexScale,
+	/// Output the metadata in a json object containing the hex encoded scale encoding of the metadata
+	JsonScale,
+}
+
+impl<S: AsRef<str>> From<S> for OutputFormat {
+	fn from(s: S) -> Self {
+		match s.as_ref() {
+			"human" => OutputFormat::Human,
+			"json" => OutputFormat::Json,
+			"scale" => OutputFormat::Scale,
+			"hex+scale" => OutputFormat::HexScale,
+			"json+scale" => OutputFormat::JsonScale,
+			_ => panic!("Unknown output format"),
+		}
+	}
+}
+
 pub struct MetadataWrapper<'a>(pub &'a RuntimeMetadata);
 
 impl<'a> MetadataWrapper<'a> {
+	pub fn write<O: Write>(
+		&self,
+		fmt: OutputFormat,
+		filter: Option<String>,
+		out: &mut O,
+	) -> Result<(), Box<dyn std::error::Error>> {
+		debug!("Writing metadata: fmt={:?}, filter={:?}", fmt, filter);
+
+		match fmt {
+			OutputFormat::Human => {
+				if let Some(filter) = filter {
+					self.write_single_module(&filter, out)?;
+				} else {
+					self.write_modules_list(out)?;
+				}
+			}
+			OutputFormat::Json => {
+				if filter.is_some() {
+					return Err("Cannot filter metadata in json format".into());
+				} else {
+					serde_json::to_writer_pretty(out, &self.0)?;
+				}
+			}
+			OutputFormat::Scale => {
+				if filter.is_some() {
+					return Err("Cannot filter metadata in scale format".into());
+				} else {
+					out.write_all(&self.0.encode())?;
+				}
+			}
+			OutputFormat::HexScale => {
+				if filter.is_some() {
+					return Err("Cannot filter metadata in hex+scale format".into());
+				} else {
+					let encoded = self.0.encode();
+					write!(out, "0x{}", hex::encode(encoded))?;
+				}
+			}
+			OutputFormat::JsonScale => {
+				if filter.is_some() {
+					return Err("Cannot filter metadata in json+scale format".into());
+				} else {
+					let encoded = self.0.encode();
+					let hex = format!("0x{}", hex::encode(encoded));
+					let json = serde_json::to_string_pretty(&serde_json::json!({ "result": hex }))?;
+					write!(out, "{}", json)?;
+				}
+			}
+		}
+		Ok(())
+	}
+
 	/// Display a simple list of the modules.
 	/// Starting with V12, modules are identified by indexes so
 	/// the order they appear in the metadata no longer matters and we sort them by indexes.
-	pub fn display_modules_list(&self) {
+	pub fn write_modules_list<O: Write>(&self, out: &mut O) -> Result<(), Box<dyn std::error::Error>> {
 		match &self.0 {
 			RuntimeMetadata::V12(v12) => {
 				let mut modules = convert(&v12.modules).clone();
 				modules.sort_by(|a, b| a.index.cmp(&b.index));
-				modules.iter().for_each(|module| println!(" - {:02}: {}", module.index, convert(&module.name)));
+				modules.iter().try_for_each(|module| -> std::io::Result<()> {
+					write!(out, " - {:02}: {}\n", module.index, convert(&module.name))
+				})?;
 			}
 			RuntimeMetadata::V13(v13) => {
 				let mut modules = convert(&v13.modules).clone();
 				modules.sort_by(|a, b| a.index.cmp(&b.index));
-				modules.iter().for_each(|module| println!(" - {:02}: {}", module.index, convert(&module.name)));
+				modules.iter().try_for_each(|module| -> std::io::Result<()> {
+					write!(out, " - {:02}: {}\n", module.index, convert(&module.name))
+				})?;
 			}
 			RuntimeMetadata::V14(v14) => {
 				let mut pallets = v14.pallets.clone();
 				// pallets.sort_by(|a,b| a.index.cmp(&b.index));
 				pallets.sort_by_key(|p| p.index);
-				pallets.iter().for_each(|pallet| println!(" - {:02}: {}", pallet.index, pallet.name));
+				pallets.iter().try_for_each(|pallet| -> std::io::Result<()> {
+					write!(out, " - {:02}: {}\n", pallet.index, pallet.name)
+				})?;
 			}
 			_ => panic!("Runtime not supported. Subwasm supports V12 and above."),
 		};
+		Ok(())
 	}
 
 	/// Display a single module
-	pub fn display_single_module(&self, filter: &str) {
-		debug!("metadata_wapper::display_module with filter: {:?}", filter);
+	pub fn write_single_module<O: Write>(&self, filter: &str, out: &mut O) -> Result<(), Box<dyn std::error::Error>> {
+		debug!("metadata_wapper::write_module with filter: {:?}", filter);
 
 		match &self.0 {
 			RuntimeMetadata::V12(v12) => {
-				display_module!(convert(&v12.modules), filter);
+				write_module!(convert(&v12.modules), filter, out);
 			}
 			RuntimeMetadata::V13(v13) => {
-				display_module!(convert(&v13.modules), filter);
+				write_module!(convert(&v13.modules), filter, out);
 			}
 			RuntimeMetadata::V14(v14) => {
 				let meta = v14
@@ -51,30 +142,31 @@ impl<'a> MetadataWrapper<'a> {
 					})
 					.expect("pallet not found in metadata");
 
-				println!("Module {:02}: {}", meta.index, &meta.name);
+				write!(out, "Module {:02}: {}\n", meta.index, &meta.name)?;
 
-				println!("🤙 Calls:");
-				display_v14_meta!(v14, meta, calls);
+				write!(out, "🤙 Calls:\n")?;
+				write_v14_meta!(v14, meta, calls, out);
 
-				println!("📢 Events:");
-				display_v14_meta!(v14, meta, event);
+				write!(out, "📢 Events:\n")?;
+				write_v14_meta!(v14, meta, event, out);
 
-				println!("⛔️ Errors:");
-				display_v14_meta!(v14, meta, error);
+				write!(out, "⛔️ Errors:\n")?;
+				write_v14_meta!(v14, meta, error, out);
 
-				println!("📦 Storage:");
+				write!(out, "📦 Storage:\n")?;
 				if let Some(meta) = &meta.storage {
 					for entry in &meta.entries {
-						println!("- {}", entry.name);
+						write!(out, "- {}\n", entry.name)?;
 					}
 				}
 
-				println!("💎 Constants:");
+				write!(out, "💎 Constants:\n")?;
 				for item in &meta.constants {
-					println!("- {}", item.name);
+					write!(out, "- {}\n", item.name)?;
 				}
 			}
-			_ => panic!("Runtime not supported"),
+			_ => panic!("Runtime not supported\n"),
 		};
+		Ok(())
 	}
 }

--- a/lib/src/subwasm.rs
+++ b/lib/src/subwasm.rs
@@ -64,7 +64,7 @@ impl Subwasm {
 		fmt: metadata_wrapper::OutputFormat,
 		filter: Option<String>,
 		out: &mut O,
-	) -> Result<(), Box<dyn std::error::Error>> {
+	) -> color_eyre::Result<()> {
 		let metadata = self.testbed.runtime_metadata_prefixed();
 		let wrapper = MetadataWrapper(&metadata.1);
 		wrapper.write(fmt, filter, out)

--- a/lib/src/subwasm.rs
+++ b/lib/src/subwasm.rs
@@ -4,9 +4,7 @@ use crate::{
 	metadata_wrapper::{self, MetadataWrapper},
 	RuntimeInfo,
 };
-use calm_io::stdoutln;
-use frame_metadata::{decode_different::DecodeDifferent, RuntimeMetadata, RuntimeMetadataPrefixed};
-use scale_info::scale::Encode;
+
 use wasm_loader::Source;
 use wasm_testbed::{WasmTestBed, WasmTestbedError};
 

--- a/lib/src/subwasm.rs
+++ b/lib/src/subwasm.rs
@@ -1,6 +1,9 @@
+use std::io::Write;
+
 use crate::{convert::convert, metadata_wrapper::MetadataWrapper, RuntimeInfo};
 use calm_io::stdoutln;
 use frame_metadata::{decode_different::DecodeDifferent, RuntimeMetadata};
+use scale_info::scale::Encode;
 use wasm_loader::Source;
 use wasm_testbed::{WasmTestBed, WasmTestbedError};
 
@@ -111,5 +114,21 @@ impl Subwasm {
 				_ => Err(e),
 			},
 		};
+	}
+
+	/// Write the prefixed runtime metadata as scale encoded bytes to a file
+	pub fn write_metadata_scale<T: AsRef<std::path::Path>>(&self, path: T) {
+		let metadata = self.testbed.runtime_metadata_prefixed();
+		let mut file = std::fs::File::create(path).unwrap();
+		let mut bytes = Vec::new();
+		metadata.encode_to(&mut bytes);
+		file.write_all(&bytes).unwrap();
+	}
+
+	/// Write the prefixed runtime metadata as json to a file
+	pub fn write_metadata_json<T: AsRef<std::path::Path>>(&self, path: T) {
+		let metadata = self.testbed.runtime_metadata_prefixed();
+		let mut file = std::fs::File::create(path).unwrap();
+		serde_json::to_writer_pretty(&mut file, &metadata).unwrap();
 	}
 }

--- a/libs/wasm-testbed/src/lib.rs
+++ b/libs/wasm-testbed/src/lib.rs
@@ -231,7 +231,7 @@ mod tests {
 		#[ignore = "local data"]
 		fn it_loads_v12() {
 			let runtime = WasmTestBed::new(&Source::File(PathBuf::from(RUNTIME_V12))).unwrap();
-			println!("{:#?}", runtime);
+			println!("{runtime:#?}");
 			assert!(runtime.metadata_version == 12);
 			assert!(runtime.is_supported());
 		}
@@ -240,7 +240,7 @@ mod tests {
 		#[ignore = "local data"]
 		fn it_loads_v13() {
 			let runtime = WasmTestBed::new(&Source::File(PathBuf::from(RUNTIME_V13))).unwrap();
-			println!("{:#?}", runtime);
+			println!("{runtime:#?}");
 			assert!(runtime.metadata_version == 13);
 			assert!(runtime.is_supported());
 		}
@@ -269,7 +269,7 @@ mod tests {
 		#[ignore = "local data"]
 		fn it_loads_kusama_1050() {
 			let runtime = WasmTestBed::new(&Source::File(PathBuf::from(KUSAMA_1050_VXX))).unwrap();
-			println!("{:#?}", runtime);
+			println!("{runtime:#?}");
 			assert!(runtime.metadata_version == 11);
 			assert!(runtime.is_supported());
 		}
@@ -279,7 +279,7 @@ mod tests {
 		#[ignore = "local data"]
 		fn it_loads_kusama_1062() {
 			let runtime = WasmTestBed::new(&Source::File(PathBuf::from(KUSAMA_1062_VXX))).unwrap();
-			println!("{:#?}", runtime);
+			println!("{runtime:#?}");
 			assert!(runtime.metadata_version == 11);
 			assert!(runtime.is_supported());
 
@@ -296,7 +296,7 @@ mod tests {
 		#[ignore = "local data"]
 		fn it_loads_kusama_metdata() {
 			let runtime = WasmTestBed::new(&Source::File(PathBuf::from(KUSAMA_2030_VXX))).unwrap();
-			println!("{:#?}", runtime);
+			println!("{runtime:#?}");
 			assert!(runtime.metadata_version == 12);
 			assert!(runtime.is_supported());
 		}
@@ -305,7 +305,7 @@ mod tests {
 		#[ignore = "local data"]
 		fn it_loads_kusama_2030() {
 			let runtime = WasmTestBed::new(&Source::File(PathBuf::from(KUSAMA_2030_VXX))).unwrap();
-			println!("{:#?}", runtime);
+			println!("{runtime:#?}");
 			assert!(runtime.metadata_version == 12);
 			assert!(runtime.is_supported());
 
@@ -328,7 +328,7 @@ mod tests {
 		#[ignore = "local data"]
 		fn it_loads_polkadot_01() {
 			let runtime = WasmTestBed::new(&Source::File(PathBuf::from(POLKADOT_01_V11))).unwrap();
-			println!("{:#?}", runtime);
+			println!("{runtime:#?}");
 			assert!(runtime.metadata_version == 11);
 			assert!(runtime.is_supported());
 		}
@@ -338,7 +338,7 @@ mod tests {
 		fn it_loads_polkadot_29() {
 			let runtime = WasmTestBed::new(&Source::File(PathBuf::from(POLKADOT_29_V12))).unwrap();
 
-			println!("{:#?}", runtime);
+			println!("{runtime:#?}");
 
 			assert!(runtime.metadata_version == 12);
 			assert!(runtime.is_supported());
@@ -353,7 +353,7 @@ mod tests {
 		#[ignore = "local data"]
 		fn it_loads_westend_30() {
 			let runtime = WasmTestBed::new(&Source::File(PathBuf::from(WESTEND_V30_V12))).unwrap();
-			println!("{:#?}", runtime);
+			println!("{runtime:#?}");
 			assert!(runtime.metadata_version == 12);
 			assert!(runtime.is_supported());
 		}
@@ -367,7 +367,7 @@ mod tests {
 		#[ignore = "local data"]
 		fn it_loads_polkadot_dev() {
 			let runtime = WasmTestBed::new(&Source::File(PathBuf::from(POLKADOT_DEV))).unwrap();
-			println!("{:#?}", runtime);
+			println!("{runtime:#?}");
 			assert!(runtime.metadata_version == 12);
 			assert!(runtime.is_supported());
 		}


### PR DESCRIPTION
This adds a `--output` flag to the metadata subcommand. If specified, the prefixed scale-encoded metadata is written to the file as expected by for example subxt or the polkadotjs/api augmentation scripts. If the global `--json` flag is set, the json of the prefixed metadata is written to the file.

The normal json output is not changed to not break backward compability.

We need this because we want to expose the metadata of our chain directly from CI and don't want to spin up a local parachain setup just to query the metadata from a live node.

Ps: I really like this tool, getting the metadata directly from the wasm is super nice!

edit: Fixes https://github.com/chevdor/subwasm/issues/58