### PR TITLE
Extended version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3519,6 +3519,7 @@ dependencies = [
  "color-eyre",
  "env_logger",
  "log",
+ "serde_json",
  "substrate-runtime-proposal-hash",
  "subwasmlib",
  "wasm-loader",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -34,6 +34,7 @@ clap = { version = "4.0", features = [
 color-eyre = "0.6"
 env_logger = "0.10"
 log = "0.4"
+serde_json = "1.0"
 substrate-runtime-proposal-hash = { version = "0.19.0", path = "../libs/substrate-runtime-proposal-hash", optional = true }
 subwasmlib = { version = "0.19.0", path = "../lib" }
 wasm-loader = { version = "0.19.0", path = "../libs/wasm-loader" }

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -1,11 +1,10 @@
 use std::{borrow::Cow, process::Command};
-// use chrono;
 
 fn main() {
 	generate_cargo_keys();
 }
 
-/// Generate the `cargo:` key output
+/// Generate the cargo keys
 pub fn generate_cargo_keys() {
 	generate_cargo_key_git();
 	generate_cargo_key_build_date();
@@ -35,9 +34,6 @@ pub fn generate_cargo_key_git() {
 	let commit = if let Ok(hash) = std::env::var("SUBWASM_CLI_GIT_COMMIT_HASH") {
 		Cow::from(hash.trim().to_owned())
 	} else {
-		// We deliberately set the length here to `11` to ensure that
-		// the emitted hash is always of the same length; otherwise
-		// it can (and will!) vary between different build environments.
 		match Command::new("git").args(["rev-parse", "--short=11", "HEAD"]).output() {
 			Ok(o) if o.status.success() => {
 				let tmsp = String::from_utf8_lossy(&o.stdout).trim().to_owned();

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -1,0 +1,51 @@
+use std::{borrow::Cow, process::Command};
+// use chrono;
+
+fn main() {
+	generate_cargo_keys();
+}
+
+/// Generate the `cargo:` key output
+pub fn generate_cargo_keys() {
+	let commit = if let Ok(hash) = std::env::var("SUBWASM_CLI_GIT_COMMIT_HASH") {
+		Cow::from(hash.trim().to_owned())
+	} else {
+		// We deliberately set the length here to `11` to ensure that
+		// the emitted hash is always of the same length; otherwise
+		// it can (and will!) vary between different build environments.
+		match Command::new("git").args(["rev-parse", "--short=11", "HEAD"]).output() {
+			Ok(o) if o.status.success() => {
+				let tmsp = String::from_utf8_lossy(&o.stdout).trim().to_owned();
+				Cow::from(tmsp)
+			}
+			Ok(o) => {
+				let status = o.status;
+				println!("cargo:warning=Git command failed with status: {status}");
+				Cow::from("unknown")
+			}
+			Err(err) => {
+				println!("cargo:warning=Failed to execute git command: {err}");
+				Cow::from("unknown")
+			}
+		}
+	};
+
+	let build_date = match Command::new("date").args(["+%Y-%m-%dT%H:%M:%S%z"]).output() {
+		Ok(o) if o.status.success() => {
+			let sha = String::from_utf8_lossy(&o.stdout).trim().to_owned();
+			Cow::from(sha)
+		}
+		Ok(o) => {
+			let status = o.status;
+			println!("cargo:warning=Failed fetching the date timestamp: {status}");
+			Cow::from("unknown")
+		}
+		Err(err) => {
+			println!("cargo:warning=Failed fetching the datge: {err}");
+			Cow::from("unknown")
+		}
+	};
+
+	println!("cargo:rustc-env=SUBWASM_CLI_BUILD_DATE={build_date}");
+	println!("cargo:rustc-env=SUBWASM_CLI_GIT_COMMIT_HASH={commit}");
+}

--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -5,7 +5,7 @@ use wasm_loader::{OnchainBlock, Source};
 
 /// `subwasm` allows fetching, parsing and calling some methods on WASM runtimes of Substrate based chains.
 #[derive(Parser)]
-#[clap(version = crate_version!(), author = crate_authors!(), color=ColorChoice::Auto)]
+#[clap(color=ColorChoice::Auto, disable_version_flag = true)]
 pub struct Opts {
 	/// Output as json
 	#[clap(short, long, global = true)]
@@ -16,7 +16,11 @@ pub struct Opts {
 	pub quiet: bool,
 
 	#[clap(subcommand)]
-	pub subcmd: SubCommand,
+	pub subcmd: Option<SubCommand>,
+
+	/// Show the version
+	#[clap(short, long, alias = "V")]
+	pub version: bool,
 }
 
 /// You can find all available commands below.


### PR DESCRIPTION
Swap the `--version` command for a new one:
```
$ subwasm --version

subwasm v0.19.0-f40bf1c04dd built 2023-02-09T15:10:59+0100
```

```
$ subwasm --version --json

{
  "build_date": "2023-02-09T15:10:59+0100",
  "commit": "f40bf1c04dd",
  "name": "subwasm",
  "version": "0.19.0"
}
```
