### PR TITLE
Fix `jsonrpsee` version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1758,8 +1758,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.17.0"
-source = "git+https://github.com/paritytech/jsonrpsee#1cde29c0280abfe13d6f59d91c7d6a78bb683515"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b971ce0f6cd1521ede485afc564b95b2c8e7079b9da41d4273bd9b55140a55d"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -1771,8 +1772,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-client-transport"
-version = "0.17.0"
-source = "git+https://github.com/paritytech/jsonrpsee#1cde29c0280abfe13d6f59d91c7d6a78bb683515"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ca00d975eda834826b04ad57d4e690c67439bb51b02eb0f8b7e4c30fcef8ab9"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -1792,8 +1794,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.17.0"
-source = "git+https://github.com/paritytech/jsonrpsee#1cde29c0280abfe13d6f59d91c7d6a78bb683515"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b83cca7a5a7899eed8b2935d5f755c8c4052ad66ab5b328bd34ac2b3ffd3515f"
 dependencies = [
  "anyhow",
  "async-lock",
@@ -1815,8 +1818,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-http-client"
-version = "0.17.0"
-source = "git+https://github.com/paritytech/jsonrpsee#1cde29c0280abfe13d6f59d91c7d6a78bb683515"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6483fea826f62260a88a132fa750a47b40d4218d41e3391936579533c6c67509"
 dependencies = [
  "async-trait",
  "hyper",
@@ -1833,8 +1837,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.17.0"
-source = "git+https://github.com/paritytech/jsonrpsee#1cde29c0280abfe13d6f59d91c7d6a78bb683515"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd301ccc3e08718393432d1961539d78c4580dcca86014dfe6769c308b2c08b2"
 dependencies = [
  "anyhow",
  "beef",
@@ -1846,8 +1851,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-wasm-client"
-version = "0.17.0"
-source = "git+https://github.com/paritytech/jsonrpsee#1cde29c0280abfe13d6f59d91c7d6a78bb683515"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85dc3aea8bbb844dacc45cd98d01f624e4485184149a045761888c2e5fa5a0c6"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -1856,8 +1862,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-ws-client"
-version = "0.17.0"
-source = "git+https://github.com/paritytech/jsonrpsee#1cde29c0280abfe13d6f59d91c7d6a78bb683515"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89a69852133d549b07cb37ff2d0ec540eae0d20abb75ae923f5d39bc7536d987"
 dependencies = [
  "http",
  "jsonrpsee-client-transport",

--- a/libs/wasm-loader/Cargo.toml
+++ b/libs/wasm-loader/Cargo.toml
@@ -19,9 +19,7 @@ version = "0.19.1"
 
 [dependencies]
 hex = "0.4"
-jsonrpsee = { version = "0.17", git = "https://github.com/paritytech/jsonrpsee", features = [
-    "client",
-] }
+jsonrpsee = { version = "0.17", features = ["client", ] }
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 sp-maybe-compressed-blob = { tag = "monthly-2023-04", git = "https://github.com/paritytech/substrate/" }


### PR DESCRIPTION
I'm getting the following error because of the `jsonrpsee` dependency of the `wasm-loader`:

```
error: failed to select a version for the requirement `jsonrpsee = "^0.17"`
candidate versions found which didn't match: 0.18.0
location searched: Git repository https://github.com/paritytech/jsonrpsee
required by package `wasm-loader v0.19.1 (https://github.com/chevdor/subwasm?branch=master#ce49da76)`
    ... which satisfies git dependency `wasm-loader` (locked to 0.19.1) of package `runtime-codegen v0.1.0 (/home/serban/workplace/sources/parity-bridges-common/tools/runtime-codegen)`
```

The project that I'm compiling is this: https://github.com/paritytech/parity-bridges-common/tree/master/tools/runtime-codegen

And I have to manually edit the `Cargo.lock` file in order to fix this:

```
[[package]]
name = "jsonrpsee"
version = "0.17.0"
source = "git+https://github.com/paritytech/jsonrpsee#1cde29c0280abfe13d6f59d91c7d6a78bb683515"
dependencies = [
 "jsonrpsee-client-transport 0.17.0",
 "jsonrpsee-core 0.17.0",
 "jsonrpsee-http-client 0.17.0",
 "jsonrpsee-types 0.17.0",
 "jsonrpsee-wasm-client",
 "jsonrpsee-ws-client",
]
```


I hope I didn't miss anything, but from what I understand using

```
jsonrpsee = { version = "0.17", git = "https://github.com/paritytech/jsonrpsee", features = [
    "client",
] }
```

Makes cargo believe that `https://github.com/paritytech/jsonrpsee == 0.17` which is not correct (since now 0.18 was released). And if the package has multiple dependencies that in turn depend on `jsonrpsee`, it leads to the error above.

So doing just `jsonrpsee = { version = "0.17", features = ["client", ] }` would be a solution. Or also the following would work:
```
jsonrpsee = { git = "https://github.com/paritytech/jsonrpsee", tag = "v0.17.1" features = [
    "client",
] }
```