### PR TITLE
Use `RuntimeMetadataPrefixed` instead of `RuntimeMetadata`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
     env:
       TARGET_DIR: target/production
 
-    runs-on: macos-10.15
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
         with:

--- a/lib/src/metadata_wrapper.rs
+++ b/lib/src/metadata_wrapper.rs
@@ -53,7 +53,7 @@ impl<'a> MetadataWrapper<'a> {
 				if filter.is_some() {
 					return Err(eyre!("Cannot filter metadata in json format"));
 				} else {
-					serde_json::to_writer_pretty(out, &self.0)?;
+					serde_json::to_writer_pretty(out, &self.0 .1)?;
 				}
 			}
 			OutputFormat::Scale => {

--- a/lib/src/metadata_wrapper.rs
+++ b/lib/src/metadata_wrapper.rs
@@ -53,21 +53,24 @@ impl<'a> MetadataWrapper<'a> {
 				if filter.is_some() {
 					return Err(eyre!("Cannot filter metadata in json format"));
 				} else {
-					serde_json::to_writer_pretty(out, &self.0 .1)?;
+					let runtime_metadata = &self.0 .1;
+					serde_json::to_writer_pretty(out, runtime_metadata)?;
 				}
 			}
 			OutputFormat::Scale => {
 				if filter.is_some() {
 					return Err(eyre!("Cannot filter metadata in scale format"));
 				} else {
-					out.write_all(&self.0.encode())?;
+					let runtime_metadata_prefixed = &self.0;
+					out.write_all(&runtime_metadata_prefixed.encode())?;
 				}
 			}
 			OutputFormat::HexScale => {
 				if filter.is_some() {
 					return Err(eyre!("Cannot filter metadata in hex+scale format"));
 				} else {
-					let encoded = self.0.encode();
+					let runtime_metadata_prefixed = &self.0;
+					let encoded = runtime_metadata_prefixed.encode();
 					write!(out, "0x{}", hex::encode(encoded))?;
 				}
 			}
@@ -75,7 +78,8 @@ impl<'a> MetadataWrapper<'a> {
 				if filter.is_some() {
 					return Err(eyre!("Cannot filter metadata in json+scale format"));
 				} else {
-					let encoded = self.0.encode();
+					let runtime_metadata_prefixed = &self.0;
+					let encoded = runtime_metadata_prefixed.encode();
 					let hex = format!("0x{}", hex::encode(encoded));
 					let json = serde_json::to_string_pretty(&serde_json::json!({ "result": hex }))?;
 					write!(out, "{json}")?;

--- a/lib/src/metadata_wrapper.rs
+++ b/lib/src/metadata_wrapper.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 
 use color_eyre::eyre::eyre;
-use frame_metadata::RuntimeMetadata;
+use frame_metadata::{RuntimeMetadata, RuntimeMetadataPrefixed};
 use log::debug;
 use scale_info::scale::Encode;
 
@@ -35,7 +35,7 @@ impl<S: AsRef<str>> From<S> for OutputFormat {
 	}
 }
 
-pub struct MetadataWrapper<'a>(pub &'a RuntimeMetadata);
+pub struct MetadataWrapper<'a>(pub &'a RuntimeMetadataPrefixed);
 
 impl<'a> MetadataWrapper<'a> {
 	pub fn write<O: Write>(&self, fmt: OutputFormat, filter: Option<String>, out: &mut O) -> color_eyre::Result<()> {
@@ -89,7 +89,7 @@ impl<'a> MetadataWrapper<'a> {
 	/// Starting with V12, modules are identified by indexes so
 	/// the order they appear in the metadata no longer matters and we sort them by indexes.
 	pub fn write_modules_list<O: Write>(&self, out: &mut O) -> color_eyre::Result<()> {
-		match &self.0 {
+		match &self.0 .1 {
 			RuntimeMetadata::V12(v12) => {
 				let mut modules = convert(&v12.modules).clone();
 				modules.sort_by(|a, b| a.index.cmp(&b.index));
@@ -121,7 +121,7 @@ impl<'a> MetadataWrapper<'a> {
 	pub fn write_single_module<O: Write>(&self, filter: &str, out: &mut O) -> color_eyre::Result<()> {
 		debug!("metadata_wapper::write_module with filter: {:?}", filter);
 
-		match &self.0 {
+		match &self.0 .1 {
 			RuntimeMetadata::V12(v12) => {
 				write_module!(convert(&v12.modules), filter, out);
 			}

--- a/lib/src/subwasm.rs
+++ b/lib/src/subwasm.rs
@@ -66,7 +66,7 @@ impl Subwasm {
 		out: &mut O,
 	) -> color_eyre::Result<()> {
 		let metadata = self.testbed.runtime_metadata_prefixed();
-		let wrapper = MetadataWrapper(&metadata.1);
+		let wrapper = MetadataWrapper(metadata);
 		wrapper.write(fmt, filter, out)
 	}
 }


### PR DESCRIPTION
The `MetadataWrapper` from `subwasm` always wrapped around the `RuntimeMetadata`, fetching it from the `RuntimeMetadataPrefixed` which is defined as:
```
pub struct RuntimeMetadataPrefixed(pub u32, pub RuntimeMetadata);
```

This became an issue when exporting the `.scale` format since `subxt` expects a serialized `RuntimeMetadataPrefixed` and `subwasm` was providing the inner `RuntimeMetadata`, missing the `u32` prefix.

This PR modifies the wrapper to allow exporting the prefix as well and make the scale export from `subwasm` compatible with `subxt` ❤️ 

related to #61 