### PR TITLE
feat: add flag for new check_version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4378,6 +4378,7 @@ dependencies = [
  "blake2",
  "frame-metadata 16.0.0 (git+https://github.com/paritytech/frame-metadata?branch=main)",
  "hex",
+ "log",
  "parity-scale-codec",
  "sp-core",
  "sp-io",

--- a/README.md
+++ b/README.md
@@ -212,6 +212,9 @@ MacOS Homebrew users can use:
 
 By default, the ID for the Parachain pallet is expected to be `0x01` and the call ID for `authorize_upgrade` is expected to be `0x03`.
 This default behavior can be overriden by setting the `PARACHAIN_PALLET_ID` to the ID of your parachain pallet and the `AUTHORIZE_UPGRADE_PREFIX` to the ID of your choice.
+Also, because of a recent [breaking change to the `parachainSystem::authorizeUpgrade` extrinsic](https://github.com/paritytech/cumulus/commit/3249186fe643f62ca95769e2217f858dde803ab6), a new `checkVersion` boolean flag is required on chains running on Cumulus v0.9.41 and above.
+This new behavior is supported by the `AUTHORIZE_UPGRADE_CHECK_VERSION` env variable, which, if set, is evaluated to `true` if its value is the string `"true"`, or false otherwise.
+If not set, the behavior remains the same as pre-0.9.41.
 
 ### Command: version
 

--- a/doc/index.adoc
+++ b/doc/index.adoc
@@ -15,6 +15,7 @@ include::usage_info.adoc[]
 
 NOTE: By default, the ID for the Parachain pallet is expected to be `0x01` and the call ID for `authorize_upgrade` is expected to be `0x03`.
 This default behavior can be overriden by setting the `PARACHAIN_PALLET_ID` to the ID of your parachain pallet and the `AUTHORIZE_UPGRADE_PREFIX` to the ID of your choice.
+The new `check_spec_version` parameter can be provided with the `AUTHORIZE_UPGRADE_CHECK_VERSION=true` or `AUTHORIZE_UPGRADE_CHECK_VERSION=false` variable, if needed.
 
 === Command: version
 ----

--- a/libs/substrate-runtime-proposal-hash/Cargo.toml
+++ b/libs/substrate-runtime-proposal-hash/Cargo.toml
@@ -18,6 +18,7 @@ readme = "README.md"
 repository = "https://github.com/chevdor/subwasm"
 
 [dependencies]
+log = "0.4"
 hex = "0.4"
 blake2 = "0.10"
 thiserror = "1.0"

--- a/libs/substrate-runtime-proposal-hash/src/lib.rs
+++ b/libs/substrate-runtime-proposal-hash/src/lib.rs
@@ -25,7 +25,6 @@ pub const AUTHORIZE_UPGRADE_PREFIX_ENV: &str = "AUTHORIZE_UPGRADE_PREFIX";
 pub const DEFAULT_AUTHORIZE_UPGRADE_PREFIX: &str = "0x02";
 
 pub const AUTHORIZE_UPGRADE_CHECK_VERSION_ENV: &str = "AUTHORIZE_UPGRADE_CHECK_VERSION";
-pub const DEFAULT_AUTHORIZE_UPGRADE_CHECK_VERSION: bool = true;
 
 /// This struct is a container for whatever we calculated.
 #[derive(Debug)]

--- a/libs/wasm-testbed/src/lib.rs
+++ b/libs/wasm-testbed/src/lib.rs
@@ -201,7 +201,7 @@ impl WasmTestBed {
 			.map(|var| if var == "true" { Some(true) } else { Some(false) })
 			.unwrap_or_else(|_| None);
 		if check_version.is_none() {
-			log::warn!("Env variable `{AUTHORIZE_UPGRADE_CHECK_VERSION_ENV}` not specified. If you are running on Substrate >= 0.9.41, this will most likely yield wrong values for the `parachainSystem::authorizeUpgrade` call hash.");
+			log::warn!("Env variable `{AUTHORIZE_UPGRADE_CHECK_VERSION_ENV}` not specified. If your chain is running on Substrate >= 0.9.41, this will most likely yield wrong values for the `parachainSystem::authorizeUpgrade` call hash.");
 		}
 
 		let decoded1 = <[u8; 1]>::from_hex(&s1).map_err(|_| RuntimePropHashError::HexDecoding(s1))?;

--- a/libs/wasm-testbed/src/lib.rs
+++ b/libs/wasm-testbed/src/lib.rs
@@ -197,9 +197,12 @@ impl WasmTestBed {
 		let s2 = env::var(AUTHORIZE_UPGRADE_PREFIX_ENV)
 			.unwrap_or_else(|_| DEFAULT_AUTHORIZE_UPGRADE_PREFIX.into())
 			.replacen("0x", "", 1);
-		let maybe_check_version = env::var(AUTHORIZE_UPGRADE_CHECK_VERSION_ENV)
+		let check_version = env::var(AUTHORIZE_UPGRADE_CHECK_VERSION_ENV)
 			.map(|var| if var == "true" { Some(true) } else { Some(false) })
 			.unwrap_or_else(|_| None);
+		if check_version.is_none() {
+			log::warn!("Env variable `{AUTHORIZE_UPGRADE_CHECK_VERSION_ENV}` not specified. If you are running on Substrate >= 0.9.41, this will most likely yield wrong values for the `parachainSystem::authorizeUpgrade` call hash.");
+		}
 
 		let decoded1 = <[u8; 1]>::from_hex(&s1).map_err(|_| RuntimePropHashError::HexDecoding(s1))?;
 		let decoded2 = <[u8; 1]>::from_hex(&s2).map_err(|_| RuntimePropHashError::HexDecoding(s2))?;
@@ -208,18 +211,11 @@ impl WasmTestBed {
 		let authorize_upgrade_prefix = *decoded2.first().expect("Failure while fecthing the Auhtorize upgrade ID");
 
 		let parachainsystem_authorize_upgrade_prefix = (parachain_pallet_id, authorize_upgrade_prefix);
-		let result = if let Some(check_version) = maybe_check_version {
-			get_parachainsystem_authorize_upgrade_with_check_version(
-				parachainsystem_authorize_upgrade_prefix,
-				&self.bytes,
-				check_version,
-			)
-		} else {
-			get_parachainsystem_authorize_upgrade_without_check_version(
-				parachainsystem_authorize_upgrade_prefix,
-				&self.bytes,
-			)
-		}?;
+		let result = get_parachainsystem_authorize_upgrade(
+			parachainsystem_authorize_upgrade_prefix,
+			&self.bytes,
+			check_version,
+		)?;
 		Ok(format!("0x{}", hex::encode(result)))
 	}
 


### PR DESCRIPTION
Fixes https://github.com/chevdor/subwasm/issues/87.

To maintain retro-compatibility, I added a new optional env variable that, if set, triggers the new behaviour. If not set, the loggers generates a warning, since most chains by now should be using the new extrinsic version anyway.